### PR TITLE
Modified SystemInfo by creating sourceRepo string

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/SystemInfo.java
@@ -4,14 +4,15 @@ import lombok.Data;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.Builder;
-import lombok.AccessLevel;
 
+import lombok.AccessLevel;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 public class SystemInfo {
-  private Boolean springH2ConsoleEnabled;
-  private Boolean showSwaggerUILink;
+	String sourceRepo;
+	private Boolean springH2ConsoleEnabled;
+	private Boolean showSwaggerUILink;
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/SystemInfo.java
@@ -12,7 +12,7 @@ import lombok.AccessLevel;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 public class SystemInfo {
-	String sourceRepo;
+	private String sourceRepo;
 	private Boolean springH2ConsoleEnabled;
 	private Boolean showSwaggerUILink;
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImpl.java
@@ -22,8 +22,12 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.showSwaggerUILink:false}")
   private boolean showSwaggerUILink;
 
+  @Value("${SOURCE_REPO:${env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-happycows}}")
+  private String sourceRepo;  
+
   public SystemInfo getSystemInfo() {
     SystemInfo si = SystemInfo.builder()
+    .sourceRepo(this.sourceRepo)
     .springH2ConsoleEnabled(this.springH2ConsoleEnabled)
     .showSwaggerUILink(this.showSwaggerUILink)
     .build();

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImpl.java
@@ -22,8 +22,8 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.showSwaggerUILink:false}")
   private boolean showSwaggerUILink;
 
-  @Value("${SOURCE_REPO:${env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-happycows}}")
-  private String sourceRepo;  
+  @Value("${app.sourcerepo:https://github.com/ucsb-cs156/proj-happycows}")
+  private String sourceRepo; 
 
   public SystemInfo getSystemInfo() {
     SystemInfo si = SystemInfo.builder()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,6 +18,7 @@ management.endpoints.web.exposure.include=mappings
 springfox.documentation.swagger.v2.path=/api/docs
 spring.jpa.hibernate.ddl-auto=update
 app.admin.emails=${ADMIN_EMAILS:${env.ADMIN_EMAILS:phtcon@ucsb.edu}}
+app.sourceRepo=${SOURCE_REPO:${env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-courses}}
 
 spring.mvc.pathmatch.matching-strategy = ANT_PATH_MATCHER
 server.compression.enabled=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,7 +18,7 @@ management.endpoints.web.exposure.include=mappings
 springfox.documentation.swagger.v2.path=/api/docs
 spring.jpa.hibernate.ddl-auto=update
 app.admin.emails=${ADMIN_EMAILS:${env.ADMIN_EMAILS:phtcon@ucsb.edu}}
-app.sourceRepo=${SOURCE_REPO:${env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-courses}}
+app.sourceRepo=${SOURCE_REPO:${env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-happycows}}
 
 spring.mvc.pathmatch.matching-strategy = ANT_PATH_MATCHER
 server.compression.enabled=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,7 +18,7 @@ management.endpoints.web.exposure.include=mappings
 springfox.documentation.swagger.v2.path=/api/docs
 spring.jpa.hibernate.ddl-auto=update
 app.admin.emails=${ADMIN_EMAILS:${env.ADMIN_EMAILS:phtcon@ucsb.edu}}
-app.sourceRepo=${SOURCE_REPO:${env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-happycows}}
+app.sourcerepo=${SOURCE_REPO:${env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-happycows}}
 
 spring.mvc.pathmatch.matching-strategy = ANT_PATH_MATCHER
 server.compression.enabled=false

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImplTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImplTests.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.happiercows.services;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -29,7 +30,9 @@ class SystemInfoServiceImplTests  {
 
   @Test
   void test_getSystemInfo() {
+    String expected = System.getenv("SOURCE_REPO:");
     SystemInfo si = systemInfoService.getSystemInfo();
+    assertEquals(expected, si.getSourceRepo());
     assertTrue(si.getSpringH2ConsoleEnabled());
     assertTrue(si.getShowSwaggerUILink());
   }

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImplTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImplTests.java
@@ -29,7 +29,7 @@ class SystemInfoServiceImplTests  {
   @Autowired
   private SystemInfoService systemInfoService;
 
-  @Value("${app.sourcerepo:https://github.com/ucsb-cs156/proj-happycows}}")
+  @Value("${app.sourcerepo:https://github.com/ucsb-cs156/proj-happycows}")
   private String expected;
 
   @Test

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImplTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImplTests.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -22,15 +23,17 @@ import edu.ucsb.cs156.happiercows.models.SystemInfo;
 
 @ExtendWith(SpringExtension.class)
 @EnableConfigurationProperties(value = SystemInfoServiceImpl.class)
-@TestPropertySource("classpath:application-development.properties")
+@TestPropertySource(locations = {"classpath:application.properties", "classpath:application-development.properties"})
 class SystemInfoServiceImplTests  {
   
   @Autowired
   private SystemInfoService systemInfoService;
 
+  @Value("${app.sourcerepo:https://github.com/ucsb-cs156/proj-happycows}}")
+  private String expected;
+
   @Test
   void test_getSystemInfo() {
-    String expected = System.getenv("SOURCE_REPO:");
     SystemInfo si = systemInfoService.getSystemInfo();
     assertEquals(expected, si.getSourceRepo());
     assertTrue(si.getSpringH2ConsoleEnabled());


### PR DESCRIPTION
1. Created String to hold source repo and initialized String in SystemInfoSerivceImpl.java.
2. Created Tests in SystemIinfoServicetests.
3. Added app.sourceRepo in application.properities and initiated value

Can test by launching the backend with swagger and testing system-info-controller as shown below:

![Clicking on source code](https://user-images.githubusercontent.com/63878759/202594445-16fe9d96-8830-41a7-bcf9-36b9f7035fb4.gif)

The return body should return "sourceRepo": "https://github.com/ucsb-cs156/proj-happycows", or the specified link in the env file.

Closes #2 