### PR TITLE
Change the footer to get the source repository from API call

### DIFF
--- a/frontend/src/fixtures/systemInfoFixtures.js
+++ b/frontend/src/fixtures/systemInfoFixtures.js
@@ -1,11 +1,13 @@
 const systemInfoFixtures = {
     showingBoth:
     {
+        "sourceRepo": "https://example.com/sourcerepository",
         "springH2ConsoleEnabled": true,
         "showSwaggerUILink": true
     },
     showingNeither:
     {
+        "sourceRepo": "https://example.com/sourcerepository",
         "springH2ConsoleEnabled": false,
         "showSwaggerUILink": false
     }

--- a/frontend/src/fixtures/systemInfoFixtures.js
+++ b/frontend/src/fixtures/systemInfoFixtures.js
@@ -1,13 +1,13 @@
 const systemInfoFixtures = {
     showingBoth:
     {
-        "sourceRepo": "https://example.com/sourcerepository",
+        "sourceRepo": "https://example.com/source/repo",
         "springH2ConsoleEnabled": true,
         "showSwaggerUILink": true
     },
     showingNeither:
     {
-        "sourceRepo": "https://example.com/sourcerepository",
+        "sourceRepo": "https://example.com/source/repo",
         "springH2ConsoleEnabled": false,
         "showSwaggerUILink": false
     }

--- a/frontend/src/main/components/Nav/Footer.js
+++ b/frontend/src/main/components/Nav/Footer.js
@@ -7,9 +7,8 @@ export default function Footer({ systemInfo }) {
         <p data-testid="footer-content">
           HappierCows is a project of <a href="https://devries.chem.ucsb.edu/mattanjah-de-vries">Mattanjah de Vries</a>, 
           Distinguished Professor of Chemistry at UC Santa Barbara.
-          The open source code is available on <a href={ systemInfo?.sourceRepo ?? "about:blank" }>GitHub</a>.
+          The open source code is available on <a data-testid="sourceRepo" href={ systemInfo?.sourceRepo ?? "about:blank" }>GitHub</a>.
         </p>
-        
       </Container>
     </footer>
   );

--- a/frontend/src/main/components/Nav/Footer.js
+++ b/frontend/src/main/components/Nav/Footer.js
@@ -1,13 +1,13 @@
 import { Container } from "react-bootstrap";
 
-export default function Footer() {
+export default function Footer({ systemInfo }) {
   return (
     <footer className="bg-light pt-3 pt-md-4 pb-4 pb-md-5">
       <Container>
         <p data-testid="footer-content">
           HappierCows is a project of <a href="https://devries.chem.ucsb.edu/mattanjah-de-vries">Mattanjah de Vries</a>, 
-          Distinguished Professor of Chemistry at UC Santa Barbara. 
-          The open source code is available on <a href="https://github.com/ucsb-cs156-s22/s22-6pm-happycows">GitHub</a>. 
+          Distinguished Professor of Chemistry at UC Santa Barbara.
+          The open source code is available on <a href={ systemInfo?.sourceRepo ?? "about:blank" }>GitHub</a>.
         </p>
         
       </Container>

--- a/frontend/src/main/layouts/BasicLayout/BasicLayout.js
+++ b/frontend/src/main/layouts/BasicLayout/BasicLayout.js
@@ -17,7 +17,7 @@ export default function BasicLayout({ children }) {
       <Container expand="xl" className="pt-4 flex-grow-1">
         {children}
       </Container>
-      <Footer />
+      <Footer systemInfo={systemInfo} />
     </div>
   );
 }

--- a/frontend/src/stories/components/Footer/Footer.stories.js
+++ b/frontend/src/stories/components/Footer/Footer.stories.js
@@ -1,0 +1,28 @@
+
+import React from 'react';
+
+import Footer from "main/components/Nav/Footer";
+import { systemInfoFixtures } from 'fixtures/systemInfoFixtures';
+
+export default {
+    title: 'components/Nav/Footer',
+    component: Footer
+};
+
+
+const Template = (args) => {
+    return (
+        <Footer {...args} />
+    )
+};
+
+export const definedSourceRepo = Template.bind({},
+    { systemInfo: systemInfoFixtures.showingBoth,}
+);
+
+export const undefinedSourceRepo = Template.bind({}, {
+    systemInfo: {
+        ...systemInfoFixtures.showingBoth,
+        sourceRepo: undefined,
+    },
+});

--- a/frontend/src/tests/components/Nav/Footer.test.js
+++ b/frontend/src/tests/components/Nav/Footer.test.js
@@ -1,7 +1,12 @@
 import { render, screen } from "@testing-library/react";
 import Footer from "main/components/Nav/Footer";
+import {QueryClient, QueryClientProvider} from "react-query";
+import {systemInfoFixtures} from "../../../fixtures/systemInfoFixtures";
+import {MemoryRouter} from "react-router-dom";
 
 describe("Footer tests", () => {
+    const queryClient = new QueryClient();
+
     test("renders correctly", async () => {
         render(
             <Footer />
@@ -11,5 +16,37 @@ describe("Footer tests", () => {
         expect(text).toBeInTheDocument();
         expect(typeof(text.textContent)).toBe('string');
         expect(text.textContent).toEqual('HappierCows is a project of Mattanjah de Vries, Distinguished Professor of Chemistry at UC Santa Barbara. The open source code is available on GitHub.');
+    });
+
+    test("source repo link is pulled from `/api/sourceInfo`", async () => {
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <Footer systemInfo={systemInfo}/>
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        const sourceRepoAnchor = await screen.findByTestId("sourceRepo");
+        expect(sourceRepoAnchor).toBeInTheDocument();
+        expect(sourceRepoAnchor.getAttribute("href")).toBe(systemInfo.sourceRepo);
+    });
+
+    test("source repo links to `about:blank` when sourceRepo returned is nullish", async () => {
+        const systemInfo = { ...systemInfoFixtures.showingBoth, sourceRepo: undefined };
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <Footer systemInfo={systemInfo}/>
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        const sourceRepoAnchor = await screen.findByTestId("sourceRepo");
+        expect(sourceRepoAnchor).toBeInTheDocument();
+        expect(sourceRepoAnchor.getAttribute("href")).toBe("about:blank");
     });
 });


### PR DESCRIPTION
- Linked source repository now gets the URL from the `/api/systemInfo` endpoint, from the `sourceRepo` key
- When the `sourceRepo` key is undefined or not present, the link is instead substituted with `about:blank`
- Added footer to Storybook
- Add relevant tests
- Closes #1 