### PR TITLE
pc - fix ci/cd so that github actions 12 and 14 fail if jacoco, pitest doesn't have full coverage  

### DIFF
--- a/.github/workflows/12-backend-jacoco.yml
+++ b/.github/workflows/12-backend-jacoco.yml
@@ -24,8 +24,10 @@ jobs:
     - name: Build with Maven
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-      run: mvn -B test jacoco:report 
-    - name: Upload to Codecov
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      run: bash <(curl -s https://codecov.io/bash)
+      run: mvn -B test jacoco:report verify
+    - name: Upload jacoco report to Artifacts
+      if: always() # always upload artifacts, even if tests fail
+      uses: actions/upload-artifact@v2
+      with:
+        name: jacoco-report
+        path: target/site/jacoco/*

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -26,9 +26,11 @@ jobs:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
       run: mvn -B test 
     - name: Pitest
-      run: mvn test org.pitest:pitest-maven:mutationCoverage
+      run: mvn test org.pitest:pitest-maven:mutationCoverage -DmutationThreshold=100 
     - name: Upload Pitest to Artifacts
+      if: always() # always upload artifacts, even if tests fail
       uses: actions/upload-artifact@v2
       with:
         name: pitest-mutation-testing
         path: target/pit-reports/* 
+

--- a/pom.xml
+++ b/pom.xml
@@ -103,13 +103,7 @@
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <version>4.2.0</version>
-        </dependency>
-
-        <!-- to manage security context in async threads; see: https://www.baeldung.com/spring-security-async-principal-propagation -->
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-config</artifactId>
-        </dependency>
+          </dependency>
 
     </dependencies>
 
@@ -147,6 +141,41 @@
                         <goals>
                             <goal>report</goal>
                         </goals>
+                    </execution>
+                    <execution>
+                        <id>check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule implementation="org.jacoco.maven.RuleConfiguration">
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit implementation="org.jacoco.report.check.Limit">
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.00</minimum>
+                                        </limit>
+                                        <limit implementation="org.jacoco.report.check.Limit">
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.00</minimum>
+                                        </limit>
+                                        <limit implementation="org.jacoco.report.check.Limit">
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.00</minimum>
+                                        </limit>
+                                        <limit implementation="org.jacoco.report.check.Limit">
+                                            <counter>CLASS</counter>
+                                            <value>MISSEDCOUNT</value>
+                                            <maximum>0</maximum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,12 @@
             <version>4.2.0</version>
           </dependency>
 
+        <!-- to manage security context in async threads; see: https://www.baeldung.com/spring-security-async-principal-propagation -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-config</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -267,7 +267,7 @@ public class CommonsControllerTests extends ControllerTestCase {
     commons.setDegradationRate(parameters.getDegradationRate());
 
     parameters.setShowLeaderboard(false);
-    commons.setDegradationRate(parameters.getDegradationRate());
+    commons.setShowLeaderboard(parameters.getShowLeaderboard());
 
     requestBody = objectMapper.writeValueAsString(parameters);
 


### PR DESCRIPTION
In this PR, we tighten up the CI/CD pipeline to require:
* 100% line coverage and branch coverage for GitHub Action 12 to pass (jacoco)
* 100% mutation coverage for GitHub Action 14 to pass (pitest)

We also address one typo in a previous PR in the CommonsControllerTests