### PR TITLE
Edit the Join Commons column in Home Page

### DIFF
--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -50,9 +50,6 @@ export default function HomePage() {
 
   return (
     <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }}>
-
-      {console.log('commons', commons, 'commonsjoined', commonsJoined, '\n\n\n', commons.filter(unjoinedFilter(commonsJoined)))}
-
       <BasicLayout>
         <h1 data-testid="homePage-title" style={{ fontSize: "75px", borderRadius: "7px", backgroundColor: "white", opacity: ".9" }} className="text-center border-0 my-3">Howdy Farmer</h1>
         <Container>

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -50,15 +50,23 @@ export default function HomePage() {
 
   return (
     <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }}>
+
+      {console.log('commons', commons, 'commonsjoined', commonsJoined, '\n\n\n', commons.filter(unjoinedFilter(commonsJoined)))}
+
       <BasicLayout>
         <h1 data-testid="homePage-title" style={{ fontSize: "75px", borderRadius: "7px", backgroundColor: "white", opacity: ".9" }} className="text-center border-0 my-3">Howdy Farmer</h1>
         <Container>
           <Row>
             <Col sm><CommonsList commonList={commonsJoined} title="Visit A Commons" buttonText={"Visit"} buttonLink={visitButtonClick} /></Col>
-            <Col sm><CommonsList commonList={commons} title="Join A Commons" buttonText={"Join"} buttonLink={mutation.mutate} /></Col>
+            <Col sm><CommonsList commonList={commons.filter(unjoinedFilter(commonsJoined))} title="Join A New Commons" buttonText={"Join"} buttonLink={mutation.mutate} /></Col>
           </Row>
         </Container>
       </BasicLayout>
     </div>
   )
+}
+
+function unjoinedFilter(commonsJoined) {
+  const ids = commonsJoined.map(commons => commons.id);
+  return el => !ids.includes(el.id);
 }

--- a/frontend/src/tests/pages/HomePage.test.js
+++ b/frontend/src/tests/pages/HomePage.test.js
@@ -85,8 +85,9 @@ describe("HomePage tests", () => {
             </QueryClientProvider>
         );
 
-        expect(await screen.findByTestId("commonsCard-button-Join-1")).toBeInTheDocument();
-        const joinButton = screen.getByTestId("commonsCard-button-Join-1");
+        expect(await screen.findByTestId("commonsCard-button-Join-4")).toBeInTheDocument();
+        expect(await screen.findByTestId("commonsCard-button-Join-5")).toBeInTheDocument();
+        const joinButton = screen.getByTestId("commonsCard-button-Join-4");
         fireEvent.click(joinButton);
     });
 });


### PR DESCRIPTION
In this PR we make the following changes to the join commons column:
- Change title from "Join A Commons" to "Join A New Commons"
- Only display unjoined commons in the column

Closes #24 