### PR TITLE
nm-tk Changes all table backgrounds to white

### DIFF
--- a/frontend/src/main/components/OurTable.js
+++ b/frontend/src/main/components/OurTable.js
@@ -3,6 +3,10 @@ import { useTable, useSortBy } from 'react-table'
 import { Table, Button } from "react-bootstrap";
 import Plaintext from "main/components/Utils/Plaintext";
 
+var tableStyle = {
+  "background": "white"
+};
+
 export default function OurTable({ columns, data, testid = "testid", ...rest }) {
 
   const {
@@ -20,7 +24,7 @@ export default function OurTable({ columns, data, testid = "testid", ...rest }) 
   }, useSortBy)
 
   return (
-    <Table {...getTableProps()} striped bordered hover >
+    <Table style={tableStyle} {...getTableProps()} striped bordered hover >
       <thead>
         {headerGroups.map(headerGroup => (
           <tr {...headerGroup.getHeaderGroupProps()}>
@@ -61,7 +65,7 @@ export default function OurTable({ columns, data, testid = "testid", ...rest }) 
           )
         })}
       </tbody>
-    </Table>
+    </Table >
   )
 }
 


### PR DESCRIPTION
Closes #25 - changes backgrounds of all tables to white to improve text visibility over picture background:

![image](https://user-images.githubusercontent.com/73052468/204121038-aa80931c-386a-4268-977a-c920700ccf88.png)
