### PR TITLE
AG - added column called username to leaderboard that maps user id to the correct username

### DIFF
--- a/frontend/src/fixtures/leaderboardFixtures.js
+++ b/frontend/src/fixtures/leaderboardFixtures.js
@@ -1,162 +1,181 @@
 const leaderboardFixtures = {
-    oneUserCommonsLB: 
-    [
-        {
-            "id":1,
-            "userId": 1,
-            "commonsId": 1,
-            "totalWealth" : 1000,
-            "numOfCows": 5
-        }
-    ],
+    oneUserCommonsLB:
+        [
+            {
+                "id": 1,
+                "userId": 1,
+                "username": "one",
+                "commonsId": 1,
+                "totalWealth": 1000,
+                "numOfCows": 5
+            }
+        ],
     threeUserCommonsLB:
-    [
-        {
-            "id":1,
-            "userId": 1,
-            "commonsId": 1,
-            "totalWealth" : 1000,
-            "numOfCows": 8
-        },
-        {
-            "id":2,
-            "userId": 2,
-            "commonsId": 1,
-            "totalWealth" : 1000,
-            "numOfCows": 5
-        },
-        {
-            "id":3,
-            "userId": 3,
-            "commonsId": 1,
-            "totalWealth" : 100000,
-            "numOfCows": 1000
-        }
-    ],
-    fiveUserCommonsLB: 
-    [
-        {
-            "id":1,
-            "userId": 1,
-            "commonsId": 1,
-            "totalWealth" : 1000,
-            "cowHealth": 93.0,
-            "numOfCows": 8
-        },
-        {
-            "id":2,
-            "userId": 2,
-            "commonsId": 1,
-            "totalWealth" : 1000,
-            "cowHealth": 98.0,
-            "numOfCows": 5
-        },
-        {
-            "id":3,
-            "userId": 3,
-            "commonsId": 1,
-            "totalWealth" : 100000,
-            "cowHealth": 2.0,
-            "numOfCows": 1000
-        },
-        {
-            "id":4,
-            "userId": 4,
-            "commonsId": 1,
-            "totalWealth" : 50,
-            "cowHealth": 84.0,
-            "numOfCows": 100
-        },
-        {
-            "id":5,
-            "userId": 5,
-            "commonsId": 1,
-            "totalWealth" : 800,
-            "numOfCows": 60
-        }
-    ],
-    tenUserCommonsLB: 
-    [
-        {
-            "id":1,
-            "userId": 1,
-            "commonsId": 1,
-            "totalWealth" : 1000,
-            "cowHealth": 93.0,
-            "numOfCows": 8
-        },
-        {
-            "id":2,
-            "userId": 2,
-            "commonsId": 1,
-            "totalWealth" : 1000,
-            "cowHealth": 98.0,
-            "numOfCows": 5
-        },
-        {
-            "id":3,
-            "userId": 3,
-            "commonsId": 1,
-            "totalWealth" : 100000,
-            "cowHealth": 2.0,
-            "numOfCows": 1000
-        },
-        {
-            "id":4,
-            "userId": 4,
-            "commonsId": 1,
-            "totalWealth" : 50,
-            "cowHealth": 84.0,
-            "numOfCows": 100
-        },
-        {
-            "id":5,
-            "userId": 5,
-            "commonsId": 1,
-            "totalWealth" : 800,
-            "cowHealth": 72.0,
-            "numOfCows": 60
-        },
-        {
-            "id":6,
-            "userId": 6,
-            "commonsId": 1,
-            "totalWealth" : 1000,
-            "cowHealth": 93.0,
-            "numOfCows": 8
-        },
-        {
-            "id":7,
-            "userId": 7,
-            "commonsId": 1,
-            "totalWealth" : 1000,
-            "cowHealth": 98.0,
-            "numOfCows": 5
-        },
-        {
-            "id":8,
-            "userId": 8,
-            "commonsId":  1,
-            "totalWealth" : 100000,
-            "cowHealth": 2.0,
-            "numOfCows": 1000
-        },
-        {
-            "id":9,
-            "userId": 9,
-            "commonsId":  1,
-            "totalWealth" : 50,
-            "cowHealth": 84.0,
-            "numOfCows": 100
-        },
-        {
-            "id":10,
-            "userId": 10,
-            "commonsId": 1,
-            "totalWealth" : 800,
-            "numOfCows": 60
-        }
-    ]
+        [
+            {
+                "id": 1,
+                "userId": 1,
+                "username": "one",
+                "commonsId": 1,
+                "totalWealth": 1000,
+                "numOfCows": 8
+            },
+            {
+                "id": 2,
+                "userId": 2,
+                "username": "two",
+                "commonsId": 1,
+                "totalWealth": 1000,
+                "numOfCows": 5
+            },
+            {
+                "id": 3,
+                "userId": 3,
+                "username": "three",
+                "commonsId": 1,
+                "totalWealth": 100000,
+                "numOfCows": 1000
+            }
+        ],
+    fiveUserCommonsLB:
+        [
+            {
+                "id": 1,
+                "userId": 1,
+                "username": "one",
+                "commonsId": 1,
+                "totalWealth": 1000,
+                "cowHealth": 93.0,
+                "numOfCows": 8
+            },
+            {
+                "id": 2,
+                "userId": 2,
+                "username": "two",
+                "commonsId": 1,
+                "totalWealth": 1000,
+                "cowHealth": 98.0,
+                "numOfCows": 5
+            },
+            {
+                "id": 3,
+                "userId": 3,
+                "username": "three",
+                "commonsId": 1,
+                "totalWealth": 100000,
+                "cowHealth": 2.0,
+                "numOfCows": 1000
+            },
+            {
+                "id": 4,
+                "userId": 4,
+                "username": "four",
+                "commonsId": 1,
+                "totalWealth": 50,
+                "cowHealth": 84.0,
+                "numOfCows": 100
+            },
+            {
+                "id": 5,
+                "userId": 5,
+                "username": "five",
+                "commonsId": 1,
+                "totalWealth": 800,
+                "numOfCows": 60
+            }
+        ],
+    tenUserCommonsLB:
+        [
+            {
+                "id": 1,
+                "userId": 1,
+                "username": "one",
+                "commonsId": 1,
+                "totalWealth": 1000,
+                "cowHealth": 93.0,
+                "numOfCows": 8
+            },
+            {
+                "id": 2,
+                "userId": 2,
+                "commonsId": 1,
+                "username": "two",
+                "totalWealth": 1000,
+                "cowHealth": 98.0,
+                "numOfCows": 5
+            },
+            {
+                "id": 3,
+                "userId": 3,
+                "username": "three",
+                "commonsId": 1,
+                "totalWealth": 100000,
+                "cowHealth": 2.0,
+                "numOfCows": 1000
+            },
+            {
+                "id": 4,
+                "userId": 4,
+                "username": "four",
+                "commonsId": 1,
+                "totalWealth": 50,
+                "cowHealth": 84.0,
+                "numOfCows": 100
+            },
+            {
+                "id": 5,
+                "userId": 5,
+                "username": "five",
+                "commonsId": 1,
+                "totalWealth": 800,
+                "cowHealth": 72.0,
+                "numOfCows": 60
+            },
+            {
+                "id": 6,
+                "userId": 6,
+                "username": "six",
+                "commonsId": 1,
+                "totalWealth": 1000,
+                "cowHealth": 93.0,
+                "numOfCows": 8
+            },
+            {
+                "id": 7,
+                "userId": 7,
+                "username": "seven",
+                "commonsId": 1,
+                "totalWealth": 1000,
+                "cowHealth": 98.0,
+                "numOfCows": 5
+            },
+            {
+                "id": 8,
+                "userId": 8,
+                "username": "eight",
+                "commonsId": 1,
+                "totalWealth": 100000,
+                "cowHealth": 2.0,
+                "numOfCows": 1000
+            },
+            {
+                "id": 9,
+                "userId": 9,
+                "username": "nine",
+                "commonsId": 1,
+                "totalWealth": 50,
+                "cowHealth": 84.0,
+                "numOfCows": 100
+            },
+            {
+                "id": 10,
+                "userId": 10,
+                "username": "ten",
+                "commonsId": 1,
+                "totalWealth": 800,
+                "numOfCows": 60
+            }
+        ]
 }
 
 export default leaderboardFixtures;

--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -2,12 +2,16 @@ import OurTable from "main/components/OurTable";
 import { hasRole } from "main/utils/currentUser";
 
 // should take in a players list from a commons
-export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
+export default function LeaderboardTable({ leaderboardUsers, currentUser }) {
 
     const columns = [
         {
             Header: 'User Id',
-            accessor: 'userId', 
+            accessor: 'userId',
+        },
+        {
+            Header: 'Username',
+            accessor: 'username',
         },
         {
             Header: 'Total Wealth',
@@ -15,7 +19,7 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
         },
         {
             Header: 'Cows Owned',
-            accessor: 'numOfCows', 
+            accessor: 'numOfCows',
         },
     ];
 

--- a/frontend/src/main/components/OurTable.js
+++ b/frontend/src/main/components/OurTable.js
@@ -4,9 +4,9 @@ import { Table, Button } from "react-bootstrap";
 import Plaintext from "main/components/Utils/Plaintext";
 
 // Stryker disable all
-var tableStyle = {
-  "background": "white"
-};
+// var tableStyle = {
+//   "background": "white"
+// };
 // Stryker enable all
 
 export default function OurTable({ columns, data, testid = "testid", ...rest }) {

--- a/frontend/src/main/components/OurTable.js
+++ b/frontend/src/main/components/OurTable.js
@@ -3,10 +3,6 @@ import { useTable, useSortBy } from 'react-table'
 import { Table, Button } from "react-bootstrap";
 import Plaintext from "main/components/Utils/Plaintext";
 
-var tableStyle = {
-  "background": "white"
-};
-
 export default function OurTable({ columns, data, testid = "testid", ...rest }) {
 
   const {
@@ -24,7 +20,7 @@ export default function OurTable({ columns, data, testid = "testid", ...rest }) 
   }, useSortBy)
 
   return (
-    <Table style={tableStyle} {...getTableProps()} striped bordered hover >
+    <Table {...getTableProps()} striped bordered hover >
       <thead>
         {headerGroups.map(headerGroup => (
           <tr {...headerGroup.getHeaderGroupProps()}>
@@ -65,7 +61,7 @@ export default function OurTable({ columns, data, testid = "testid", ...rest }) 
           )
         })}
       </tbody>
-    </Table >
+    </Table>
   )
 }
 

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -62,11 +62,7 @@ export default function PlayPage() {
   // Stryker enable all 
 
   const onSuccessBuy = () => {
-	// The value for totalWealth updates late, the current totalWealth is always the previous totalWealth.
-	// Thats why only need to compare the current totalWealth to the cowPrice, because this implies that 
-	// totalWealth - cowPrice aka current totalWealth will not be enough to buy a cow.
-	if(!(userCommons.totalWealth < commons.cowPrice)) toast(`Cow bought!`);
-	else toast(`You can't buy a cow because you don't have enough money`)
+    toast(`Cow bought!`);
   }
 
   const objectToAxiosParamsBuy = (newUserCommons) => ({

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -8,8 +8,8 @@ import leaderboardFixtures from "fixtures/leaderboardFixtures";
 const mockedNavigate = jest.fn();
 
 jest.mock('react-router-dom', () => ({
-    ...jest.requireActual('react-router-dom'),
-    useNavigate: () => mockedNavigate
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedNavigate
 }));
 
 describe("LeaderboardTable tests", () => {
@@ -65,8 +65,8 @@ describe("LeaderboardTable tests", () => {
 
     );
 
-    const expectedHeaders = ['(Admin) userCommons Id', 'User Id', 'Total Wealth', 'Cows Owned'];
-    const expectedFields = ['id', 'userId', 'totalWealth','numOfCows'];
+    const expectedHeaders = ['(Admin) userCommons Id', 'Username', 'User Id', 'Total Wealth', 'Cows Owned'];
+    const expectedFields = ['id', 'userId', 'username', 'totalWealth', 'numOfCows'];
     const testId = "LeaderboardTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -81,12 +81,13 @@ describe("LeaderboardTable tests", () => {
 
     expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-userId`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-username`)).toHaveTextContent("one");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-totalWealth`)).toHaveTextContent("1000");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-userId`)).toHaveTextContent("2");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-username`)).toHaveTextContent("two");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-totalWealth`)).toHaveTextContent("1000");
 
   });
 
 });
-

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -70,21 +70,21 @@ public class CommonsController extends ApiController {
   public ResponseEntity<String> getCommonsPlus() throws JsonProcessingException {
     log.info("getCommonsPlus()...");
     Iterable<Commons> commonsListIter = commonsRepository.findAll();
-    
-    // convert Iterable to List for the purposes of using a Java Stream & lambda below
+
+    // convert Iterable to List for the purposes of using a Java Stream & lambda
+    // below
     List<Commons> commonsList = new ArrayList<Commons>();
     commonsListIter.forEach(commonsList::add);
 
     List<CommonsPlus> commonsPlusList1 = commonsList.stream()
-      .map(c->toCommonsPlus(c))
-      .collect(Collectors.toList());
+        .map(c -> toCommonsPlus(c))
+        .collect(Collectors.toList());
 
     log.info("commonsPlusList1=" + commonsPlusList1);
 
     ArrayList<CommonsPlus> commonsPlusList = new ArrayList<CommonsPlus>(commonsPlusList1);
 
     log.info("commonsPlusList=" + commonsPlusList);
-
 
     String body = mapper.writeValueAsString(commonsPlusList);
 
@@ -118,12 +118,11 @@ public class CommonsController extends ApiController {
     updated.setStartingDate(params.getStartingDate());
     updated.setEndingDate(params.getEndingDate());
     updated.setShowLeaderboard(params.getShowLeaderboard());
-    updated.setDegradationRate(params.getDegradationRate()); 
+    updated.setDegradationRate(params.getDegradationRate());
 
-    if(params.getDegradationRate() < 0){
+    if (params.getDegradationRate() < 0) {
       throw new IllegalArgumentException("Degradation Rate cannot be negative");
     }
-    
 
     commonsRepository.save(updated);
 
@@ -146,24 +145,24 @@ public class CommonsController extends ApiController {
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   @PostMapping(value = "/new", produces = "application/json")
   public ResponseEntity<String> createCommons(
-  
+
       @ApiParam("request body") @RequestBody CreateCommonsParams params) throws JsonProcessingException {
     Commons commons = Commons.builder()
-      .name(params.getName())
-      .cowPrice(params.getCowPrice())
-      .milkPrice(params.getMilkPrice())
-      .startingBalance(params.getStartingBalance())
-      .startingDate(params.getStartingDate())
-      .endingDate(params.getEndingDate())
-      .degradationRate(params.getDegradationRate())
-      .showLeaderboard(params.getShowLeaderboard())
-      .build();
-   
-    //throw exception for degradation rate 
-    if(params.getDegradationRate() < 0){
+        .name(params.getName())
+        .cowPrice(params.getCowPrice())
+        .milkPrice(params.getMilkPrice())
+        .startingBalance(params.getStartingBalance())
+        .startingDate(params.getStartingDate())
+        .endingDate(params.getEndingDate())
+        .degradationRate(params.getDegradationRate())
+        .showLeaderboard(params.getShowLeaderboard())
+        .build();
+
+    // throw exception for degradation rate
+    if (params.getDegradationRate() < 0) {
       throw new IllegalArgumentException("Degradation Rate cannot be negative");
     }
-    
+
     Commons saved = commonsRepository.save(commons);
     String body = mapper.writeValueAsString(saved);
 
@@ -178,6 +177,7 @@ public class CommonsController extends ApiController {
 
     User u = getCurrentUser().getUser();
     Long userId = u.getId();
+    String username = u.getFullName();
 
     Commons joinedCommons = commonsRepository.findById(commonsId)
         .orElseThrow(() -> new EntityNotFoundException(Commons.class, commonsId));
@@ -192,6 +192,7 @@ public class CommonsController extends ApiController {
     UserCommons uc = UserCommons.builder()
         .commonsId(commonsId)
         .userId(userId)
+        .username(username)
         .totalWealth(joinedCommons.getStartingBalance())
         .numOfCows(0)
         .build();
@@ -237,11 +238,11 @@ public class CommonsController extends ApiController {
   public CommonsPlus toCommonsPlus(Commons c) {
     Optional<Integer> numCows = commonsRepository.getNumCows(c.getId());
     Optional<Integer> numUsers = commonsRepository.getNumUsers(c.getId());
-    
+
     return CommonsPlus.builder()
-    .commons(c)
-    .totalCows(numCows.orElse(0))
-    .totalUsers(numUsers.orElse(0))
-    .build();
+        .commons(c)
+        .totalCows(numCows.orElse(0))
+        .totalUsers(numUsers.orElse(0))
+        .build();
   }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
@@ -7,7 +7,6 @@ import lombok.NonNull;
 import lombok.Builder;
 import lombok.AccessLevel;
 
-
 import javax.persistence.*;
 
 @Data
@@ -18,16 +17,17 @@ import javax.persistence.*;
 public class UserCommons {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private long id;  
+  private long id;
 
-  @Column(name="commons_id")
-  private long commonsId;  
+  @Column(name = "commons_id")
+  private long commonsId;
 
-  @Column(name="user_id")
-  private long userId;  
+  @Column(name = "user_id")
+  private long userId;
+
+  private String username;
 
   private double totalWealth;
 
   private int numOfCows;
 }
-

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,394 +48,394 @@ import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 @AutoConfigureDataJpa
 public class CommonsControllerTests extends ControllerTestCase {
 
-  @MockBean
-  UserCommonsRepository userCommonsRepository;
-
-  @MockBean
-  UserRepository userRepository;
-
-  @MockBean
-  CommonsRepository commonsRepository;
-
-  @Autowired
-  private ObjectMapper objectMapper;
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void createCommonsTest() throws Exception {
-    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
-    LocalDateTime someOtherTime = LocalDateTime.parse("2022-04-20T15:50:10");
-
-    Commons commons = Commons.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .endingDate(someOtherTime)
-        .degradationRate(50.0)
-        .showLeaderboard(false)
-        .build();
-
-    CreateCommonsParams parameters = CreateCommonsParams.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .endingDate(someOtherTime)
-        .degradationRate(50.0)
-        .showLeaderboard(false)
-        .build();
-
-    String requestBody = objectMapper.writeValueAsString(parameters);
-    String expectedResponse = objectMapper.writeValueAsString(commons);
-
-    when(commonsRepository.save(commons))
-        .thenReturn(commons);
-
-    MvcResult response = mockMvc
-        .perform(post("/api/commons/new").with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8")
-            .content(requestBody))
-        .andExpect(status().isOk())
-        .andReturn();
-
-    verify(commonsRepository, times(1)).save(commons);
-
-    String actualResponse = response.getResponse().getContentAsString();
-    assertEquals(expectedResponse, actualResponse);
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void createCommonsTest_zeroDegradation() throws Exception {
-    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
-    LocalDateTime someOtherTime = LocalDateTime.parse("2022-04-20T15:50:10");
-
-    Commons commons = Commons.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(0)
-        .endingDate(someOtherTime)
-        .showLeaderboard(false)
-        .build();
-
-    CreateCommonsParams parameters = CreateCommonsParams.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(0)
-        .endingDate(someOtherTime)
-        .showLeaderboard(false)
-        .build();
-
-    String requestBody = objectMapper.writeValueAsString(parameters);
-    String expectedResponse = objectMapper.writeValueAsString(commons);
-
-    when(commonsRepository.save(commons))
-        .thenReturn(commons);
-
-    MvcResult response = mockMvc
-        .perform(post("/api/commons/new").with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8")
-            .content(requestBody))
-        .andExpect(status().isOk())
-        .andReturn();
-
-    verify(commonsRepository, times(1)).save(commons);
-
-    String actualResponse = response.getResponse().getContentAsString();
-    assertEquals(expectedResponse, actualResponse);
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void createCommonsTest_withIllegalDegradationRate() throws Exception {
-    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
-
-    Commons commons = Commons.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(-8.49)
-        .build();
-
-    CreateCommonsParams parameters = CreateCommonsParams.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(-8.49)
-        .build();
-
-    String requestBody = objectMapper.writeValueAsString(parameters);
-
-    when(commonsRepository.save(commons))
-        .thenReturn(commons);
-
-    MvcResult response = mockMvc
-        .perform(post("/api/commons/new").with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8")
-            .content(requestBody))
-        .andExpect(status().isBadRequest()).andReturn();
-
-    Optional<IllegalArgumentException> someException = Optional
-        .ofNullable((IllegalArgumentException) response.getResolvedException());
-
-    assertNotNull(someException.get());
-    assertTrue(someException.get() instanceof IllegalArgumentException);
-  }
-
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void getCommonsTest() throws Exception {
-    List<Commons> expectedCommons = new ArrayList<Commons>();
-    Commons Commons1 = Commons.builder().name("TestCommons1").build();
-
-    expectedCommons.add(Commons1);
-    when(commonsRepository.findAll()).thenReturn(expectedCommons);
-    MvcResult response = mockMvc.perform(get("/api/commons/all").contentType("application/json"))
-        .andExpect(status().isOk()).andReturn();
-
-    verify(commonsRepository, times(1)).findAll();
-
-    String responseString = response.getResponse().getContentAsString();
-    List<Commons> actualCommons = objectMapper.readValue(responseString, new TypeReference<List<Commons>>() {
-    });
-    assertEquals(actualCommons, expectedCommons);
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void updateCommonsTest() throws Exception {
-    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
-    LocalDateTime someOtherTime = LocalDateTime.parse("2022-04-20T15:50:10");
-
-    CreateCommonsParams parameters = CreateCommonsParams.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .endingDate(someOtherTime)
-        .degradationRate(50.0)
-        .showLeaderboard(true)
-        .build();
-
-    Commons commons = Commons.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .endingDate(someOtherTime)
-        .degradationRate(50.0)
-        .showLeaderboard(true)
-        .build();
-
-    String requestBody = objectMapper.writeValueAsString(parameters);
-
-    when(commonsRepository.save(commons))
-        .thenReturn(commons);
-
-    mockMvc
-        .perform(put("/api/commons/update?id=0").with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8")
-            .content(requestBody))
-        .andExpect(status().isCreated());
-
-    verify(commonsRepository, times(1)).save(commons);
-
-    parameters.setMilkPrice(parameters.getMilkPrice() + 3.00);
-    commons.setMilkPrice(parameters.getMilkPrice());
-
-    parameters.setDegradationRate(parameters.getDegradationRate() + 1.00);
-    commons.setDegradationRate(parameters.getDegradationRate());
-
-    parameters.setShowLeaderboard(false);
-    commons.setShowLeaderboard(parameters.getShowLeaderboard());
-
-    requestBody = objectMapper.writeValueAsString(parameters);
-
-    when(commonsRepository.findById(0L))
-        .thenReturn(Optional.of(commons));
-
-    when(commonsRepository.save(commons))
-        .thenReturn(commons);
-
-    mockMvc
-        .perform(put("/api/commons/update?id=0").with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8")
-            .content(requestBody))
-        .andExpect(status().isNoContent());
-
-    verify(commonsRepository, times(1)).save(commons);
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void updateCommonsTest_withDegradationRate_Zero() throws Exception {
-    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
-    LocalDateTime someOtherTime = LocalDateTime.parse("2022-04-20T15:50:10");
-
-    CreateCommonsParams parameters = CreateCommonsParams.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(8.49)
-        .endingDate(someOtherTime)
-        .showLeaderboard(false)
-        .build();
-
-    Commons commons = Commons.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(8.49)
-        .endingDate(someOtherTime)
-        .showLeaderboard(false)
-        .build();
-
-    String requestBody = objectMapper.writeValueAsString(parameters);
-
-    when(commonsRepository.save(commons))
-        .thenReturn(commons);
-
-    mockMvc
-        .perform(put("/api/commons/update?id=0").with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8")
-            .content(requestBody))
-        .andExpect(status().isCreated());
-
-    verify(commonsRepository, times(1)).save(commons);
-
-    parameters.setMilkPrice(parameters.getMilkPrice() + 3.00);
-    commons.setMilkPrice(parameters.getMilkPrice());
-    parameters.setDegradationRate(0);
-    commons.setDegradationRate(parameters.getDegradationRate());
-
-    requestBody = objectMapper.writeValueAsString(parameters);
-
-    when(commonsRepository.findById(0L))
-        .thenReturn(Optional.of(commons));
-
-    when(commonsRepository.save(commons))
-        .thenReturn(commons);
-
-    mockMvc
-        .perform(put("/api/commons/update?id=0").with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8")
-            .content(requestBody))
-        .andExpect(status().isNoContent());
-
-    verify(commonsRepository, times(1)).save(commons);
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void updateCommonsTest_withIllegalDegradationRate() throws Exception {
-    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
-
-    CreateCommonsParams parameters = CreateCommonsParams.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(8.49)
-        .showLeaderboard(false)
-        .build();
-
-    Commons commons = Commons.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(8.49)
-        .showLeaderboard(false)
-        .build();
-
-    String requestBody = objectMapper.writeValueAsString(parameters);
-
-    when(commonsRepository.save(commons))
-        .thenReturn(commons);
-
-    mockMvc
-        .perform(put("/api/commons/update?id=0").with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8")
-            .content(requestBody))
-        .andExpect(status().isCreated());
-
-    verify(commonsRepository, times(1)).save(commons);
-
-    parameters.setDegradationRate(-10);
-    commons.setDegradationRate(parameters.getDegradationRate());
-
-    requestBody = objectMapper.writeValueAsString(parameters);
-
-    when(commonsRepository.findById(0L))
-        .thenReturn(Optional.of(commons));
-
-    when(commonsRepository.save(commons))
-        .thenReturn(commons);
-
-    MvcResult response = mockMvc
-        .perform(put("/api/commons/update?id=0").with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8")
-            .content(requestBody))
-        .andExpect(status().isBadRequest()).andReturn();
-
-    Optional<IllegalArgumentException> someException = Optional
-        .ofNullable((IllegalArgumentException) response.getResolvedException());
-
-    assertNotNull(someException.get());
-    assertTrue(someException.get() instanceof IllegalArgumentException);
-  }
-
-  // This common SHOULD be in the repository
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void getCommonsByIdTest_valid() throws Exception {
-    Commons Commons1 = Commons.builder()
-        .name("TestCommons2")
-        .id(18L)
-        .build();
-
-    when(commonsRepository.findById(eq(18L))).thenReturn(Optional.of(Commons1));
-
-    MvcResult response = mockMvc.perform(get("/api/commons?id=18"))
-        .andExpect(status().isOk()).andReturn();
-
-    verify(commonsRepository, times(1)).findById(eq(18L));
-    String expectedJson = mapper.writeValueAsString(Commons1);
-    String responseString = response.getResponse().getContentAsString();
-    assertEquals(expectedJson, responseString);
-  }
-
-  // This common SHOULD NOT be in the repository
+    @MockBean
+    UserCommonsRepository userCommonsRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    @MockBean
+    CommonsRepository commonsRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void createCommonsTest() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime someOtherTime = LocalDateTime.parse("2022-04-20T15:50:10");
+
+        Commons commons = Commons.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .endingDate(someOtherTime)
+                .degradationRate(50.0)
+                .showLeaderboard(false)
+                .build();
+
+        CreateCommonsParams parameters = CreateCommonsParams.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .endingDate(someOtherTime)
+                .degradationRate(50.0)
+                .showLeaderboard(false)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(parameters);
+        String expectedResponse = objectMapper.writeValueAsString(commons);
+
+        when(commonsRepository.save(commons))
+                .thenReturn(commons);
+
+        MvcResult response = mockMvc
+                .perform(post("/api/commons/new").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        verify(commonsRepository, times(1)).save(commons);
+
+        String actualResponse = response.getResponse().getContentAsString();
+        assertEquals(expectedResponse, actualResponse);
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void createCommonsTest_zeroDegradation() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime someOtherTime = LocalDateTime.parse("2022-04-20T15:50:10");
+
+        Commons commons = Commons.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(0)
+                .endingDate(someOtherTime)
+                .showLeaderboard(false)
+                .build();
+
+        CreateCommonsParams parameters = CreateCommonsParams.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(0)
+                .endingDate(someOtherTime)
+                .showLeaderboard(false)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(parameters);
+        String expectedResponse = objectMapper.writeValueAsString(commons);
+
+        when(commonsRepository.save(commons))
+                .thenReturn(commons);
+
+        MvcResult response = mockMvc
+                .perform(post("/api/commons/new").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        verify(commonsRepository, times(1)).save(commons);
+
+        String actualResponse = response.getResponse().getContentAsString();
+        assertEquals(expectedResponse, actualResponse);
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void createCommonsTest_withIllegalDegradationRate() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Commons commons = Commons.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(-8.49)
+                .build();
+
+        CreateCommonsParams parameters = CreateCommonsParams.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(-8.49)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(parameters);
+
+        when(commonsRepository.save(commons))
+                .thenReturn(commons);
+
+        MvcResult response = mockMvc
+                .perform(post("/api/commons/new").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isBadRequest()).andReturn();
+
+        Optional<IllegalArgumentException> someException = Optional
+                .ofNullable((IllegalArgumentException) response.getResolvedException());
+
+        assertNotNull(someException.get());
+        assertTrue(someException.get() instanceof IllegalArgumentException);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void getCommonsTest() throws Exception {
+        List<Commons> expectedCommons = new ArrayList<Commons>();
+        Commons Commons1 = Commons.builder().name("TestCommons1").build();
+
+        expectedCommons.add(Commons1);
+        when(commonsRepository.findAll()).thenReturn(expectedCommons);
+        MvcResult response = mockMvc.perform(get("/api/commons/all").contentType("application/json"))
+                .andExpect(status().isOk()).andReturn();
+
+        verify(commonsRepository, times(1)).findAll();
+
+        String responseString = response.getResponse().getContentAsString();
+        List<Commons> actualCommons = objectMapper.readValue(responseString, new TypeReference<List<Commons>>() {
+        });
+        assertEquals(actualCommons, expectedCommons);
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void updateCommonsTest() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime someOtherTime = LocalDateTime.parse("2022-04-20T15:50:10");
+
+        CreateCommonsParams parameters = CreateCommonsParams.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .endingDate(someOtherTime)
+                .degradationRate(50.0)
+                .showLeaderboard(true)
+                .build();
+
+        Commons commons = Commons.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .endingDate(someOtherTime)
+                .degradationRate(50.0)
+                .showLeaderboard(true)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(parameters);
+
+        when(commonsRepository.save(commons))
+                .thenReturn(commons);
+
+        mockMvc
+                .perform(put("/api/commons/update?id=0").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isCreated());
+
+        verify(commonsRepository, times(1)).save(commons);
+
+        parameters.setMilkPrice(parameters.getMilkPrice() + 3.00);
+        commons.setMilkPrice(parameters.getMilkPrice());
+
+        parameters.setDegradationRate(parameters.getDegradationRate() + 1.00);
+        commons.setDegradationRate(parameters.getDegradationRate());
+
+        parameters.setShowLeaderboard(false);
+        commons.setShowLeaderboard(parameters.getShowLeaderboard());
+
+        requestBody = objectMapper.writeValueAsString(parameters);
+
+        when(commonsRepository.findById(0L))
+                .thenReturn(Optional.of(commons));
+
+        when(commonsRepository.save(commons))
+                .thenReturn(commons);
+
+        mockMvc
+                .perform(put("/api/commons/update?id=0").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isNoContent());
+
+        verify(commonsRepository, times(1)).save(commons);
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void updateCommonsTest_withDegradationRate_Zero() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime someOtherTime = LocalDateTime.parse("2022-04-20T15:50:10");
+
+        CreateCommonsParams parameters = CreateCommonsParams.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(8.49)
+                .endingDate(someOtherTime)
+                .showLeaderboard(false)
+                .build();
+
+        Commons commons = Commons.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(8.49)
+                .endingDate(someOtherTime)
+                .showLeaderboard(false)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(parameters);
+
+        when(commonsRepository.save(commons))
+                .thenReturn(commons);
+
+        mockMvc
+                .perform(put("/api/commons/update?id=0").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isCreated());
+
+        verify(commonsRepository, times(1)).save(commons);
+
+        parameters.setMilkPrice(parameters.getMilkPrice() + 3.00);
+        commons.setMilkPrice(parameters.getMilkPrice());
+        parameters.setDegradationRate(0);
+        commons.setDegradationRate(parameters.getDegradationRate());
+
+        requestBody = objectMapper.writeValueAsString(parameters);
+
+        when(commonsRepository.findById(0L))
+                .thenReturn(Optional.of(commons));
+
+        when(commonsRepository.save(commons))
+                .thenReturn(commons);
+
+        mockMvc
+                .perform(put("/api/commons/update?id=0").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isNoContent());
+
+        verify(commonsRepository, times(1)).save(commons);
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void updateCommonsTest_withIllegalDegradationRate() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        CreateCommonsParams parameters = CreateCommonsParams.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(8.49)
+                .showLeaderboard(false)
+                .build();
+
+        Commons commons = Commons.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(8.49)
+                .showLeaderboard(false)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(parameters);
+
+        when(commonsRepository.save(commons))
+                .thenReturn(commons);
+
+        mockMvc
+                .perform(put("/api/commons/update?id=0").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isCreated());
+
+        verify(commonsRepository, times(1)).save(commons);
+
+        parameters.setDegradationRate(-10);
+        commons.setDegradationRate(parameters.getDegradationRate());
+
+        requestBody = objectMapper.writeValueAsString(parameters);
+
+        when(commonsRepository.findById(0L))
+                .thenReturn(Optional.of(commons));
+
+        when(commonsRepository.save(commons))
+                .thenReturn(commons);
+
+        MvcResult response = mockMvc
+                .perform(put("/api/commons/update?id=0").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isBadRequest()).andReturn();
+
+        Optional<IllegalArgumentException> someException = Optional
+                .ofNullable((IllegalArgumentException) response.getResolvedException());
+
+        assertNotNull(someException.get());
+        assertTrue(someException.get() instanceof IllegalArgumentException);
+    }
+
+    // This common SHOULD be in the repository
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void getCommonsByIdTest_valid() throws Exception {
+        Commons Commons1 = Commons.builder()
+                .name("TestCommons2")
+                .id(18L)
+                .build();
+
+        when(commonsRepository.findById(eq(18L))).thenReturn(Optional.of(Commons1));
+
+        MvcResult response = mockMvc.perform(get("/api/commons?id=18"))
+                .andExpect(status().isOk()).andReturn();
+
+        verify(commonsRepository, times(1)).findById(eq(18L));
+        String expectedJson = mapper.writeValueAsString(Commons1);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    // This common SHOULD NOT be in the repository
   @WithMockUser(roles = { "USER" })
   @Test
   public void getCommonsByIdTest_invalid() throws Exception {
@@ -454,186 +453,192 @@ public class CommonsControllerTests extends ControllerTestCase {
     assertEquals(responseMap.get("type"), "EntityNotFoundException");
   }
 
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void joinCommonsTest() throws Exception {
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void joinCommonsTest() throws Exception {
 
-    Commons c = Commons.builder()
-        .id(2L)
-        .name("Example Commons")
-        .build();
+        Commons c = Commons.builder()
+                .id(2L)
+                .name("Example Commons")
+                .build();
 
-    UserCommons uc = UserCommons.builder()
-        .userId(1L)
-        .commonsId(2L)
-        .totalWealth(0)
-        .numOfCows(0)
-        .build();
+        UserCommons uc = UserCommons.builder()
+                .userId(1L)
+                .username("Fake user")
+                .commonsId(2L)
+                .totalWealth(0)
+                .numOfCows(0)
+                .build();
 
-    UserCommons ucSaved = UserCommons.builder()
-        .id(17L)
-        .userId(1L)
-        .commonsId(2L)
-        .totalWealth(0)
-        .numOfCows(0)
-        .build();
+        UserCommons ucSaved = UserCommons.builder()
+                .id(17L)
+                .userId(1L)
+                .username("Fake user")
+                .commonsId(2L)
+                .totalWealth(0)
+                .numOfCows(0)
+                .build();
 
-    String requestBody = mapper.writeValueAsString(uc);
+        String requestBody = mapper.writeValueAsString(uc);
 
-    when(userCommonsRepository.findByCommonsIdAndUserId(anyLong(), anyLong())).thenReturn(Optional.empty());
-    when(userCommonsRepository.save(eq(uc))).thenReturn(ucSaved);
-    when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));
+        when(userCommonsRepository.findByCommonsIdAndUserId(anyLong(), anyLong())).thenReturn(Optional.empty());
+        when(userCommonsRepository.save(eq(uc))).thenReturn(ucSaved);
+        when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));
 
-    MvcResult response = mockMvc
-        .perform(post("/api/commons/join?commonsId=2").with(csrf()).contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8").content(requestBody))
-        .andExpect(status().isOk()).andReturn();
+        MvcResult response = mockMvc
+                .perform(post("/api/commons/join?commonsId=2").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8").content(requestBody))
+                .andExpect(status().isOk()).andReturn();
 
-    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(2L, 1L);
-    verify(userCommonsRepository, times(1)).save(uc);
+        verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(2L, 1L);
+        verify(userCommonsRepository, times(1)).save(uc);
 
-    String responseString = response.getResponse().getContentAsString();
-    String cAsJson = mapper.writeValueAsString(c);
+        String responseString = response.getResponse().getContentAsString();
+        String cAsJson = mapper.writeValueAsString(c);
 
-    assertEquals(responseString, cAsJson);
-  }
+        assertEquals(responseString, cAsJson);
+    }
 
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void already_joined_common_test() throws Exception {
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void already_joined_common_test() throws Exception {
 
-    Commons c = Commons.builder()
-        .id(2L)
-        .name("Example Commons")
-        .build();
+        Commons c = Commons.builder()
+                .id(2L)
+                .name("Example Commons")
+                .build();
 
-    UserCommons uc = UserCommons.builder()
-        .userId(1L)
-        .commonsId(2L)
-        .totalWealth(0)
-        .numOfCows(1)
-        .build();
+        UserCommons uc = UserCommons.builder()
+                .userId(1L)
+                .username("Fake user")
+                .commonsId(2L)
+                .totalWealth(0)
+                .numOfCows(1)
+                .build();
 
-    String requestBody = mapper.writeValueAsString(uc);
+        String requestBody = mapper.writeValueAsString(uc);
 
-    // Instead of returning empty, we instead say that it already exists. We
-    // shouldn't create a new entry.
-    when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.of(uc));
-    when(userCommonsRepository.save(eq(uc))).thenReturn(uc);
+        // Instead of returning empty, we instead say that it already exists. We
+        // shouldn't create a new entry.
+        when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.of(uc));
+        when(userCommonsRepository.save(eq(uc))).thenReturn(uc);
 
-    when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));
+        when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));
 
-    MvcResult response = mockMvc
-        .perform(post("/api/commons/join?commonsId=2").with(csrf()).contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8").content(requestBody))
-        .andExpect(status().isOk()).andReturn();
+        MvcResult response = mockMvc
+                .perform(post("/api/commons/join?commonsId=2").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8").content(requestBody))
+                .andExpect(status().isOk()).andReturn();
 
-    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(2L, 1L);
+        verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(2L, 1L);
 
-    String responseString = response.getResponse().getContentAsString();
-    String cAsJson = mapper.writeValueAsString(c);
+        String responseString = response.getResponse().getContentAsString();
+        String cAsJson = mapper.writeValueAsString(c);
 
-    assertEquals(responseString, cAsJson);
-  }
+        assertEquals(responseString, cAsJson);
+    }
 
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void user_commons_exists_but_commons_doesnt_test() throws Exception {
-    UserCommons uc = UserCommons.builder()
-        .userId(1L)
-        .commonsId(2L)
-        .totalWealth(0)
-        .numOfCows(1)
-        .build();
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void user_commons_exists_but_commons_doesnt_test() throws Exception {
+        UserCommons uc = UserCommons.builder()
+                .userId(1L)
+                .username("Fake user")
+                .commonsId(2L)
+                .totalWealth(0)
+                .numOfCows(1)
+                .build();
 
-    String requestBody = mapper.writeValueAsString(uc);
+        String requestBody = mapper.writeValueAsString(uc);
 
-    when(commonsRepository.findById(eq(2L))).thenReturn(Optional.empty());
+        when(commonsRepository.findById(eq(2L))).thenReturn(Optional.empty());
 
-    MvcResult response = mockMvc
-        .perform(post("/api/commons/join?commonsId=2").with(csrf()).contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8").content(requestBody))
-        .andExpect(status().is(404)).andReturn();
+        MvcResult response = mockMvc
+                .perform(post("/api/commons/join?commonsId=2").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8").content(requestBody))
+                .andExpect(status().is(404)).andReturn();
 
-    verify(commonsRepository, times(1)).findById(eq(2L));
+        verify(commonsRepository, times(1)).findById(eq(2L));
 
-    Map<String, Object> responseMap = responseToJson(response);
+        Map<String, Object> responseMap = responseToJson(response);
 
-    assertEquals(responseMap.get("message"), "Commons with id 2 not found");
-    assertEquals(responseMap.get("type"), "EntityNotFoundException");
-  }
+        assertEquals(responseMap.get("message"), "Commons with id 2 not found");
+        assertEquals(responseMap.get("type"), "EntityNotFoundException");
+    }
 
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void join_and_create_userCommons_for_nonexistent_commons() throws Exception {
-    UserCommons uc = UserCommons.builder()
-        .userId(1L)
-        .commonsId(2L)
-        .totalWealth(0)
-        .numOfCows(1)
-        .build();
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void join_and_create_userCommons_for_nonexistent_commons() throws Exception {
+        UserCommons uc = UserCommons.builder()
+                .userId(1L)
+                .username("1L")
+                .commonsId(2L)
+                .totalWealth(0)
+                .numOfCows(1)
+                .build();
 
-    UserCommons ucSaved = UserCommons.builder()
-        .id(17L)
-        .userId(1L)
-        .commonsId(2L)
-        .totalWealth(0)
-        .numOfCows(1)
-        .build();
+        UserCommons ucSaved = UserCommons.builder()
+                .id(17L)
+                .userId(1L)
+                .username("1L")
+                .commonsId(2L)
+                .totalWealth(0)
+                .numOfCows(1)
+                .build();
 
-    String requestBody = mapper.writeValueAsString(uc);
+        String requestBody = mapper.writeValueAsString(uc);
 
-    when(commonsRepository.findById(eq(2L))).thenReturn(Optional.empty());
+        when(commonsRepository.findById(eq(2L))).thenReturn(Optional.empty());
 
-    MvcResult response = mockMvc
-        .perform(post("/api/commons/join?commonsId=2").with(csrf()).contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8").content(requestBody))
-        .andExpect(status().is(404)).andReturn();
+        MvcResult response = mockMvc
+                .perform(post("/api/commons/join?commonsId=2").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8").content(requestBody))
+                .andExpect(status().is(404)).andReturn();
 
-    verify(commonsRepository, times(1)).findById(eq(2L));
+        verify(commonsRepository, times(1)).findById(eq(2L));
 
-    Map<String, Object> responseMap = responseToJson(response);
+        Map<String, Object> responseMap = responseToJson(response);
 
-    assertEquals(responseMap.get("message"), "Commons with id 2 not found");
-    assertEquals(responseMap.get("type"), "EntityNotFoundException");
-  }
+        assertEquals(responseMap.get("message"), "Commons with id 2 not found");
+        assertEquals(responseMap.get("type"), "EntityNotFoundException");
+    }
 
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void deleteCommons_test_admin_exists() throws Exception {
-    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
-    LocalDateTime someOtherTime = LocalDateTime.parse("2022-04-20T15:50:10");
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void deleteCommons_test_admin_exists() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime someOtherTime = LocalDateTime.parse("2022-04-20T15:50:10");
 
-    Commons c = Commons.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .endingDate(someOtherTime)
-        .degradationRate(50.0)
-        .showLeaderboard(false)
-        .build();
+        Commons c = Commons.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .endingDate(someOtherTime)
+                .degradationRate(50.0)
+                .showLeaderboard(false)
+                .build();
 
-    when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));
-    doNothing().when(commonsRepository).deleteById(2L);
-    doNothing().when(userCommonsRepository).deleteAllByCommonsId(2L);
+        when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));
+        doNothing().when(commonsRepository).deleteById(2L);
+        doNothing().when(userCommonsRepository).deleteAllByCommonsId(2L);
 
-    MvcResult response = mockMvc.perform(
-        delete("/api/commons?id=2")
-            .with(csrf()))
-        .andExpect(status().is(200)).andReturn();
+        MvcResult response = mockMvc.perform(
+                delete("/api/commons?id=2")
+                        .with(csrf()))
+                .andExpect(status().is(200)).andReturn();
 
-    verify(commonsRepository, times(1)).findById(2L);
-    verify(commonsRepository, times(1)).deleteById(2L);
-    verify(userCommonsRepository, times(1)).deleteAllByCommonsId(2L);
+        verify(commonsRepository, times(1)).findById(2L);
+        verify(commonsRepository, times(1)).deleteById(2L);
+        verify(userCommonsRepository, times(1)).deleteAllByCommonsId(2L);
 
-    String responseString = response.getResponse().getContentAsString();
+        String responseString = response.getResponse().getContentAsString();
 
-    String expectedString = "{\"message\":\"commons with id 2 deleted\"}";
+        String expectedString = "{\"message\":\"commons with id 2 deleted\"}";
 
-    assertEquals(expectedString, responseString);
-  }
+        assertEquals(expectedString, responseString);
+    }
 
   @WithMockUser(roles = { "ADMIN" })
   @Test
@@ -654,118 +659,119 @@ public class CommonsControllerTests extends ControllerTestCase {
       assertEquals(expectedJson, jsonResponse);
   }
 
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void deleteUserFromCommonsTest() throws Exception {
-    UserCommons uc = UserCommons.builder()
-        .id(16L)
-        .userId(1L)
-        .commonsId(2L)
-        .totalWealth(0)
-        .numOfCows(1)
-        .build();
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void deleteUserFromCommonsTest() throws Exception {
+        UserCommons uc = UserCommons.builder()
+                .id(16L)
+                .userId(1L)
+                .username("1L")
+                .commonsId(2L)
+                .totalWealth(0)
+                .numOfCows(1)
+                .build();
 
-    String requestBody = mapper.writeValueAsString(uc);
+        String requestBody = mapper.writeValueAsString(uc);
 
-    when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.of(uc));
+        when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.of(uc));
 
-    MvcResult response = mockMvc
-        .perform(delete("/api/commons/2/users/1").with(csrf()).contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8").content(requestBody))
-        .andExpect(status().is(204)).andReturn();
+        MvcResult response = mockMvc
+                .perform(delete("/api/commons/2/users/1").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8").content(requestBody))
+                .andExpect(status().is(204)).andReturn();
 
-    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(2L, 1L);
-    verify(userCommonsRepository, times(1)).deleteById(16L);
+        verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(2L, 1L);
+        verify(userCommonsRepository, times(1)).deleteById(16L);
 
-    String responseString = response.getResponse().getContentAsString();
+        String responseString = response.getResponse().getContentAsString();
 
-    assertEquals(responseString, "");
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void deleteUserFromCommonsTest_nonexistent_userCommons() throws Exception {
-    UserCommons uc = UserCommons.builder()
-        .id(16L)
-        .userId(1L)
-        .commonsId(2L)
-        .totalWealth(0)
-        .numOfCows(1)
-        .build();
-
-    String requestBody = mapper.writeValueAsString(uc);
-
-    when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.empty());
-
-    try {
-      mockMvc
-          .perform(delete("/api/commons/2/users/1").with(csrf()).contentType(MediaType.APPLICATION_JSON)
-              .characterEncoding("utf-8").content(requestBody))
-          .andExpect(status().is(204)).andReturn();
-
-      // The way this works is very interesting. The error message is sent as the
-      // value of a nested exception.
-    } catch (Exception e) {
-      assertEquals(e.toString(),
-          "org.springframework.web.util.NestedServletException: Request processing failed; nested exception is java.lang.Exception: UserCommons with commonsId=2 and userId=1 not found.");
+        assertEquals(responseString, "");
     }
-  }
 
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void getCommonsPlusTest() throws Exception {
-    List<Commons> expectedCommons = new ArrayList<Commons>();
-    Commons Commons1 = Commons.builder().name("TestCommons1").id(1L).build();
-    Commons Commons2 = Commons.builder().name("TestCommons2").id(2L).build();
-    Commons Commons3 = Commons.builder().name("TestCommons3").id(3L).build();
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void deleteUserFromCommonsTest_nonexistent_userCommons() throws Exception {
+        UserCommons uc = UserCommons.builder()
+                .id(16L)
+                .userId(1L)
+                .username("1L")
+                .commonsId(2L)
+                .totalWealth(0)
+                .numOfCows(1)
+                .build();
 
-    expectedCommons.add(Commons1);
-    expectedCommons.add(Commons2);
-    expectedCommons.add(Commons3);
+        String requestBody = mapper.writeValueAsString(uc);
 
-    List<CommonsPlus> expectedCommonsPlusList = new ArrayList<CommonsPlus>();
-    CommonsPlus commonsPlus1 = CommonsPlus.builder()
-        .commons(Commons1)
-        .totalCows(50)
-        .totalUsers(20)
-        .build();
+        when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.empty());
 
-    CommonsPlus commonsPlus2 = CommonsPlus.builder()
-        .commons(Commons2)
-        .totalCows(0)
-        .totalUsers(0)
-        .build();
+        try {
+            mockMvc
+                    .perform(delete("/api/commons/2/users/1").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+                            .characterEncoding("utf-8").content(requestBody))
+                    .andExpect(status().is(204)).andReturn();
 
+            // The way this works is very interesting. The error message is sent as the
+            // value of a nested exception.
+        } catch (Exception e) {
+            assertEquals(e.toString(),
+                    "org.springframework.web.util.NestedServletException: Request processing failed; nested exception is java.lang.Exception: UserCommons with commonsId=2 and userId=1 not found.");
+        }
+    }
 
-    CommonsPlus commonsPlus3 = CommonsPlus.builder()
-        .commons(Commons3)
-        .totalCows(60)
-        .totalUsers(30)
-        .build();
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void getCommonsPlusTest() throws Exception {
+        List<Commons> expectedCommons = new ArrayList<Commons>();
+        Commons Commons1 = Commons.builder().name("TestCommons1").id(1L).build();
+        Commons Commons2 = Commons.builder().name("TestCommons2").id(2L).build();
+        Commons Commons3 = Commons.builder().name("TestCommons3").id(3L).build();
 
-    expectedCommonsPlusList.add(commonsPlus1);
-    expectedCommonsPlusList.add(commonsPlus2);
-    expectedCommonsPlusList.add(commonsPlus3);
+        expectedCommons.add(Commons1);
+        expectedCommons.add(Commons2);
+        expectedCommons.add(Commons3);
 
-    when(commonsRepository.findAll()).thenReturn(expectedCommons);
-    when(commonsRepository.getNumCows(eq(1L))).thenReturn(Optional.of(50));
-    when(commonsRepository.getNumUsers(eq(1L))).thenReturn(Optional.of(20));
-    when(commonsRepository.getNumCows(eq(2L))).thenReturn(Optional.empty());
-    when(commonsRepository.getNumUsers(eq(2L))).thenReturn(Optional.empty());
-    when(commonsRepository.getNumCows(eq(3L))).thenReturn(Optional.of(60));
-    when(commonsRepository.getNumUsers(eq(3L))).thenReturn(Optional.of(30));
+        List<CommonsPlus> expectedCommonsPlusList = new ArrayList<CommonsPlus>();
+        CommonsPlus commonsPlus1 = CommonsPlus.builder()
+                .commons(Commons1)
+                .totalCows(50)
+                .totalUsers(20)
+                .build();
 
-    MvcResult response = mockMvc.perform(get("/api/commons/allplus").contentType("application/json"))
-        .andExpect(status().isOk()).andReturn();
+        CommonsPlus commonsPlus2 = CommonsPlus.builder()
+                .commons(Commons2)
+                .totalCows(0)
+                .totalUsers(0)
+                .build();
 
-    verify(commonsRepository, times(1)).findAll();
+        CommonsPlus commonsPlus3 = CommonsPlus.builder()
+                .commons(Commons3)
+                .totalCows(60)
+                .totalUsers(30)
+                .build();
 
-    String responseString = response.getResponse().getContentAsString();
-    List<CommonsPlus> actualCommonsPlus = objectMapper.readValue(responseString,
-        new TypeReference<List<CommonsPlus>>() {
-        });
+        expectedCommonsPlusList.add(commonsPlus1);
+        expectedCommonsPlusList.add(commonsPlus2);
+        expectedCommonsPlusList.add(commonsPlus3);
 
-    assertEquals(expectedCommonsPlusList, actualCommonsPlus);
-  
+        when(commonsRepository.findAll()).thenReturn(expectedCommons);
+        when(commonsRepository.getNumCows(eq(1L))).thenReturn(Optional.of(50));
+        when(commonsRepository.getNumUsers(eq(1L))).thenReturn(Optional.of(20));
+        when(commonsRepository.getNumCows(eq(2L))).thenReturn(Optional.empty());
+        when(commonsRepository.getNumUsers(eq(2L))).thenReturn(Optional.empty());
+        when(commonsRepository.getNumCows(eq(3L))).thenReturn(Optional.of(60));
+        when(commonsRepository.getNumUsers(eq(3L))).thenReturn(Optional.of(30));
+
+        MvcResult response = mockMvc.perform(get("/api/commons/allplus").contentType("application/json"))
+                .andExpect(status().isOk()).andReturn();
+
+        verify(commonsRepository, times(1)).findAll();
+
+        String responseString = response.getResponse().getContentAsString();
+        List<CommonsPlus> actualCommonsPlus = objectMapper.readValue(responseString,
+                new TypeReference<List<CommonsPlus>>() {
+                });
+
+        assertEquals(expectedCommonsPlusList, actualCommonsPlus);
+
     }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -44,40 +44,42 @@ import java.time.LocalDateTime;
 @AutoConfigureDataJpa
 public class UserCommonsControllerTests extends ControllerTestCase {
 
-  @MockBean
-  UserCommonsRepository userCommonsRepository;
+    @MockBean
+    UserCommonsRepository userCommonsRepository;
 
-  @MockBean
-  UserRepository userRepository;
+    @MockBean
+    UserRepository userRepository;
 
-  @MockBean
-  CommonsRepository commonsRepository;
+    @MockBean
+    CommonsRepository commonsRepository;
 
-  @Autowired
-  private ObjectMapper objectMapper;
+    @Autowired
+    private ObjectMapper objectMapper;
 
-  public static UserCommons dummyUserCommons(long id) {
-    UserCommons userCommons = new UserCommons(id,1,1,1,1);
-    return userCommons;
-  }
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void test_getUserCommonsById_exists_admin() throws Exception {
-  
-    UserCommons expectedUserCommons = dummyUserCommons(1);
-    when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L),eq(1L))).thenReturn(Optional.of(expectedUserCommons));
+    public static UserCommons dummyUserCommons(long id) {
+        UserCommons userCommons = new UserCommons(id, 1, 1, "test", 1, 1);
+        return userCommons;
+    }
 
-    MvcResult response = mockMvc.perform(get("/api/usercommons/?userId=1&commonsId=1"))
-        .andExpect(status().isOk()).andReturn();
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void test_getUserCommonsById_exists_admin() throws Exception {
 
-    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L),eq(1L));
+        UserCommons expectedUserCommons = dummyUserCommons(1);
+        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L)))
+                .thenReturn(Optional.of(expectedUserCommons));
 
-    String expectedJson = mapper.writeValueAsString(expectedUserCommons);
-    String responseString = response.getResponse().getContentAsString();
+        MvcResult response = mockMvc.perform(get("/api/usercommons/?userId=1&commonsId=1"))
+                .andExpect(status().isOk()).andReturn();
 
-    assertEquals(expectedJson, responseString);
-  }
-  
+        verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
+
+        String expectedJson = mapper.writeValueAsString(expectedUserCommons);
+        String responseString = response.getResponse().getContentAsString();
+
+        assertEquals(expectedJson, responseString);
+    }
+
   @WithMockUser(roles = { "ADMIN" })
   @Test
   public void test_getUserCommonsById_nonexists_admin() throws Exception {
@@ -97,24 +99,25 @@ public class UserCommonsControllerTests extends ControllerTestCase {
     assertEquals(expectedJson, jsonResponse);
   }
 
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void test_getUserCommonsById_exists() throws Exception {
-  
-    UserCommons expectedUserCommons = dummyUserCommons(1);
-    when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L),eq(1L))).thenReturn(Optional.of(expectedUserCommons));
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_getUserCommonsById_exists() throws Exception {
 
-    MvcResult response = mockMvc.perform(get("/api/usercommons/forcurrentuser?commonsId=1"))
-        .andExpect(status().isOk()).andReturn();
+        UserCommons expectedUserCommons = dummyUserCommons(1);
+        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L)))
+                .thenReturn(Optional.of(expectedUserCommons));
 
-    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L),eq(1L));
+        MvcResult response = mockMvc.perform(get("/api/usercommons/forcurrentuser?commonsId=1"))
+                .andExpect(status().isOk()).andReturn();
 
-    String expectedJson = mapper.writeValueAsString(expectedUserCommons);
-    String responseString = response.getResponse().getContentAsString();
+        verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
 
-    assertEquals(expectedJson, responseString);
-  }
-  
+        String expectedJson = mapper.writeValueAsString(expectedUserCommons);
+        String responseString = response.getResponse().getContentAsString();
+
+        assertEquals(expectedJson, responseString);
+    }
+
   @WithMockUser(roles = { "USER" })
   @Test
   public void test_getUserCommonsById_nonexists() throws Exception {
@@ -133,623 +136,618 @@ public class UserCommonsControllerTests extends ControllerTestCase {
     assertEquals(expectedJson, jsonResponse);
   }
 
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void test_BuyCow_commons_exists() throws Exception {
-  
-      // arrange
-  
-      UserCommons origUserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(1)
-      .build();
-  
-      Commons testCommons = Commons
-      .builder()
-      .name("test commons")
-      .cowPrice(10)
-      .milkPrice(2)
-      .startingBalance(300)
-      .startingDate(LocalDateTime.now())
-      .build();
-  
-      UserCommons userCommonsToSend = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(1)
-      .build();
-  
-      UserCommons correctuserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300-testCommons.getCowPrice())
-      .numOfCows(2)
-      .build();
-  
-      String requestBody = mapper.writeValueAsString(userCommonsToSend);
-      String expectedReturn = mapper.writeValueAsString(correctuserCommons);
-  
-      when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
-      when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
-  
-      // act
-      MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=1")
-          .contentType(MediaType.APPLICATION_JSON)
-                      .characterEncoding("utf-8")
-                      .content(requestBody)
-                      .with(csrf()))
-              .andExpect(status().isOk()).andReturn();
-  
-      // assert
-      verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
-      verify(userCommonsRepository, times(1)).save(correctuserCommons);
-      String responseString = response.getResponse().getContentAsString();
-      assertEquals(expectedReturn, responseString);
-  }
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_BuyCow_commons_exists() throws Exception {
 
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void test_BuyCow_commons_exists_user_has_exact_amount_needed() throws Exception {
-  
-      // arrange
-  
-      UserCommons origUserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(1)
-      .build();
-  
-      Commons testCommons = Commons
-      .builder()
-      .name("test commons")
-      .cowPrice(300)
-      .milkPrice(2)
-      .startingBalance(300)
-      .startingDate(LocalDateTime.now())
-      .build();
-  
-      UserCommons userCommonsToSend = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(1)
-      .build();
-  
-      UserCommons correctuserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(0)
-      .numOfCows(2)
-      .build();
-  
-      String requestBody = mapper.writeValueAsString(userCommonsToSend);
-      String expectedReturn = mapper.writeValueAsString(correctuserCommons);
-  
-      when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
-      when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
-  
-      // act
-      MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=1")
-          .contentType(MediaType.APPLICATION_JSON)
-                      .characterEncoding("utf-8")
-                      .content(requestBody)
-                      .with(csrf()))
-              .andExpect(status().isOk()).andReturn();
-  
-      // assert
-      verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
-      verify(userCommonsRepository, times(1)).save(correctuserCommons);
-      String responseString = response.getResponse().getContentAsString();
-      assertEquals(expectedReturn, responseString);
-  }
-  
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void test_SellCow_commons_exists() throws Exception {
-  
-      // arrange
-  
-      UserCommons origUserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(1)
-      .build();
-  
-      Commons testCommons = Commons
-      .builder()
-      .name("test commons")
-      .cowPrice(10)
-      .milkPrice(2)
-      .startingBalance(300)
-      .startingDate(LocalDateTime.now())
-      .build();
-  
-      UserCommons userCommonsToSend = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(1)
-      .build();
-  
-      UserCommons correctuserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300+testCommons.getCowPrice())
-      .numOfCows(0)
-      .build();
-  
-      String requestBody = mapper.writeValueAsString(userCommonsToSend);
-      String expectedReturn = mapper.writeValueAsString(correctuserCommons);
-  
-      when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
-      when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
-  
-      // act
-      MvcResult response = mockMvc.perform(put("/api/usercommons/sell?commonsId=1")
-          .contentType(MediaType.APPLICATION_JSON)
-                      .characterEncoding("utf-8")
-                      .content(requestBody)
-                      .with(csrf()))
-              .andExpect(status().isOk()).andReturn();
-  
-      // assert
-      verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
-      verify(userCommonsRepository, times(1)).save(correctuserCommons);
-      String responseString = response.getResponse().getContentAsString();
-      assertEquals(expectedReturn, responseString);
-  }
-  
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void test_BuyCow_commons_for_user_DOES_NOT_exist() throws Exception {
-  
-      // arrange
-  
-      UserCommons origUserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(1)
-      .build();
-  
-      Commons testCommons = Commons
-      .builder()
-      .name("test commons")
-      .cowPrice(10)
-      .milkPrice(2)
-      .startingBalance(300)
-      .startingDate(LocalDateTime.now())
-      .build();
-  
-      UserCommons userCommonsToSend = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(1)
-      .build();
-  
-      UserCommons correctuserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300-testCommons.getCowPrice())
-      .numOfCows(2)
-      .build();
-  
-      String requestBody = mapper.writeValueAsString(userCommonsToSend);
-      String expectedReturn = mapper.writeValueAsString(correctuserCommons);
-  
-      when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
-      when(commonsRepository.findById(eq(234L))).thenReturn(Optional.of(testCommons));
-  
-      // act
-      MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=234") 
-          .contentType(MediaType.APPLICATION_JSON)
-                      .characterEncoding("utf-8")
-                      .content(requestBody)
-                      .with(csrf()))
-              .andExpect(status().is(404)).andReturn();
-  
-      // assert
-  
-      String responseString = response.getResponse().getContentAsString();
-      String expectedString = "{\"message\":\"UserCommons with commonsId 234 and userId 1 not found\",\"type\":\"EntityNotFoundException\"}";
-      Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
-      Map<String, Object> jsonResponse = responseToJson(response);
-      assertEquals(expectedJson, jsonResponse);
-  }
-  
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void test_SellCow_commons_for_usercommons_DOES_NOT_exist() throws Exception {
-  
-      // arrange
-  
-      UserCommons origUserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(1)
-      .build();
-  
-      Commons testCommons = Commons
-      .builder()
-      .id(234L)
-      .name("test commons")
-      .cowPrice(10)
-      .milkPrice(2)
-      .startingBalance(300)
-      .startingDate(LocalDateTime.now())
-      .build();
-  
-      UserCommons userCommonsToSend = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(1)
-      .build();
-  
-      UserCommons correctuserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300+testCommons.getCowPrice())
-      .numOfCows(2)
-      .build();
-  
-      String requestBody = mapper.writeValueAsString(userCommonsToSend);
-      String expectedReturn = mapper.writeValueAsString(correctuserCommons);
-  
-      when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
-      when(commonsRepository.findById(eq(234L))).thenReturn(Optional.of(testCommons));
-  
-      // act
-      MvcResult response = mockMvc.perform(put("/api/usercommons/sell?commonsId=234")
-          .contentType(MediaType.APPLICATION_JSON)
-                      .characterEncoding("utf-8")
-                      .content(requestBody)
-                      .with(csrf()))
-              .andExpect(status().is(404)).andReturn();
-  
-      // assert
-      String responseString = response.getResponse().getContentAsString();
-      String expectedString = "{\"message\":\"UserCommons with commonsId 234 and userId 1 not found\",\"type\":\"EntityNotFoundException\"}";
-      Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
-      Map<String, Object> jsonResponse = responseToJson(response);
-      assertEquals(expectedJson, jsonResponse);
-  }
-  
-  //tests for when the common itself doesn't exist
-  
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void test_SellCow_commons_DOES_NOT_exist() throws Exception {
-  
-      // arrange
-  
-      UserCommons origUserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(1)
-      .build();
-  
-      Commons testCommons = Commons
-      .builder()
-      .name("test commons")
-      .cowPrice(10)
-      .milkPrice(2)
-      .startingBalance(300)
-      .startingDate(LocalDateTime.now())
-      .build();
-  
-      UserCommons userCommonsToSend = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(1)
-      .build();
-  
-      UserCommons correctuserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300+testCommons.getCowPrice())
-      .numOfCows(2)
-      .build();
-  
-      String requestBody = mapper.writeValueAsString(userCommonsToSend);
-      String expectedReturn = mapper.writeValueAsString(correctuserCommons);
-  
-      when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
-      when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
-  
-      // act
-      MvcResult response = mockMvc.perform(put("/api/usercommons/sell?commonsId=222")
-          .contentType(MediaType.APPLICATION_JSON)
-                      .characterEncoding("utf-8")
-                      .content(requestBody)
-                      .with(csrf()))
-              .andExpect(status().is(404)).andReturn();
-  
-      // assert
-      String responseString = response.getResponse().getContentAsString();
-      String expectedString = "{\"message\":\"Commons with id 222 not found\",\"type\":\"EntityNotFoundException\"}";
-      Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
-      Map<String, Object> jsonResponse = responseToJson(response);
-      assertEquals(expectedJson, jsonResponse);
-  }
-  
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void test_BuyCow_commons_DOES_NOT_exist() throws Exception {
-  
-      // arrange
-  
-      UserCommons origUserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(1)
-      .build();
-  
-      Commons testCommons = Commons
-      .builder()
-      .name("test commons")
-      .cowPrice(10)
-      .milkPrice(2)
-      .startingBalance(300)
-      .startingDate(LocalDateTime.now())
-      .build();
-  
-      UserCommons userCommonsToSend = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(1)
-      .build();
-  
-      UserCommons correctuserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300+testCommons.getCowPrice())
-      .numOfCows(2)
-      .build();
-  
-      String requestBody = mapper.writeValueAsString(userCommonsToSend);
-      String expectedReturn = mapper.writeValueAsString(correctuserCommons);
-  
-      when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
-      when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
-  
-      // act
-      MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=222")
-          .contentType(MediaType.APPLICATION_JSON)
-                      .characterEncoding("utf-8")
-                      .content(requestBody)
-                      .with(csrf()))
-              .andExpect(status().is(404)).andReturn();
-  
-      // assert
-      String responseString = response.getResponse().getContentAsString();
-      String expectedString = "{\"message\":\"Commons with id 222 not found\",\"type\":\"EntityNotFoundException\"}";
-      Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
-      Map<String, Object> jsonResponse = responseToJson(response);
-      assertEquals(expectedJson, jsonResponse);
-  }
-  
-  
-  
-  // Put tests for edge cases (not enough money to buy, or no cow to sell)
-  
-  
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void test_BuyCow_commons_exists_not_enough_money() throws Exception {
-  
-      // arrange
-  
-      UserCommons origUserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(0)
-      .numOfCows(1)
-      .build();
-  
-      Commons testCommons = Commons
-      .builder()
-      .name("test commons")
-      .cowPrice(10)
-      .milkPrice(2)
-      .startingBalance(0)
-      .startingDate(LocalDateTime.now())
-      .build();
-  
-      UserCommons userCommonsToSend = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(0)
-      .numOfCows(1)
-      .build();
-  
-      UserCommons correctuserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(0)
-      .numOfCows(1)
-      .build();
-  
-      String requestBody = mapper.writeValueAsString(userCommonsToSend);
-      String expectedReturn = mapper.writeValueAsString(correctuserCommons);
-  
-      when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
-      when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
-  
-      // act
-      MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=1")
-          .contentType(MediaType.APPLICATION_JSON)
-                      .characterEncoding("utf-8")
-                      .content(requestBody)
-                      .with(csrf()))
-              .andExpect(status().isOk()).andReturn();
-  
-      // assert
-      verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
-      verify(userCommonsRepository, times(1)).save(correctuserCommons);
-      String responseString = response.getResponse().getContentAsString();
-      assertEquals(expectedReturn, responseString);
-  }
-  
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void test_SellCow_commons_exists_no_cow_to_sell() throws Exception {
-  
-      // arrange
-  
-      UserCommons origUserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(0)
-      .build();
-  
-      Commons testCommons = Commons
-      .builder()
-      .name("test commons")
-      .cowPrice(10)
-      .milkPrice(2)
-      .startingBalance(300)
-      .startingDate(LocalDateTime.now())
-      .build();
-  
-      UserCommons userCommonsToSend = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(0)
-      .build();
-  
-      UserCommons correctuserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(0)
-      .build();
-  
-      String requestBody = mapper.writeValueAsString(userCommonsToSend);
-      String expectedReturn = mapper.writeValueAsString(correctuserCommons);
-  
-      when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
-      when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
-  
-      // act
-      MvcResult response = mockMvc.perform(put("/api/usercommons/sell?commonsId=1")
-          .contentType(MediaType.APPLICATION_JSON)
-                      .characterEncoding("utf-8")
-                      .content(requestBody)
-                      .with(csrf()))
-              .andExpect(status().isOk()).andReturn();
-  
-      // assert
-      verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
-      verify(userCommonsRepository, times(1)).save(correctuserCommons);
-      String responseString = response.getResponse().getContentAsString();
-      assertEquals(expectedReturn, responseString);
+        // arrange
+
+        UserCommons origUserCommons = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(1)
+                .build();
+
+        Commons testCommons = Commons
+                .builder()
+                .name("test commons")
+                .cowPrice(10)
+                .milkPrice(2)
+                .startingBalance(300)
+                .startingDate(LocalDateTime.now())
+                .build();
+
+        UserCommons userCommonsToSend = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(1)
+                .build();
+
+        UserCommons correctuserCommons = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300 - testCommons.getCowPrice())
+                .numOfCows(2)
+                .build();
+
+        String requestBody = mapper.writeValueAsString(userCommonsToSend);
+        String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+
+        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+        when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
+
+        // act
+        MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody)
+                .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
+        verify(userCommonsRepository, times(1)).save(correctuserCommons);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedReturn, responseString);
     }
 
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_BuyCow_commons_exists_user_has_exact_amount_needed() throws Exception {
 
+        // arrange
+
+        UserCommons origUserCommons = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(1)
+                .build();
+
+        Commons testCommons = Commons
+                .builder()
+                .name("test commons")
+                .cowPrice(300)
+                .milkPrice(2)
+                .startingBalance(300)
+                .startingDate(LocalDateTime.now())
+                .build();
+
+        UserCommons userCommonsToSend = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(1)
+                .build();
+
+        UserCommons correctuserCommons = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(0)
+                .numOfCows(2)
+                .build();
+
+        String requestBody = mapper.writeValueAsString(userCommonsToSend);
+        String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+
+        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+        when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
+
+        // act
+        MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody)
+                .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
+        verify(userCommonsRepository, times(1)).save(correctuserCommons);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedReturn, responseString);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_SellCow_commons_exists() throws Exception {
+
+        // arrange
+
+        UserCommons origUserCommons = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(1)
+                .build();
+
+        Commons testCommons = Commons
+                .builder()
+                .name("test commons")
+                .cowPrice(10)
+                .milkPrice(2)
+                .startingBalance(300)
+                .startingDate(LocalDateTime.now())
+                .build();
+
+        UserCommons userCommonsToSend = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(1)
+                .build();
+
+        UserCommons correctuserCommons = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300 + testCommons.getCowPrice())
+                .numOfCows(0)
+                .build();
+
+        String requestBody = mapper.writeValueAsString(userCommonsToSend);
+        String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+
+        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+        when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
+
+        // act
+        MvcResult response = mockMvc.perform(put("/api/usercommons/sell?commonsId=1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody)
+                .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
+        verify(userCommonsRepository, times(1)).save(correctuserCommons);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedReturn, responseString);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_BuyCow_commons_for_user_DOES_NOT_exist() throws Exception {
+
+        // arrange
+
+        UserCommons origUserCommons = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(1)
+                .build();
+
+        Commons testCommons = Commons
+                .builder()
+                .name("test commons")
+                .cowPrice(10)
+                .milkPrice(2)
+                .startingBalance(300)
+                .startingDate(LocalDateTime.now())
+                .build();
+
+        UserCommons userCommonsToSend = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(1)
+                .build();
+
+        UserCommons correctuserCommons = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300 - testCommons.getCowPrice())
+                .numOfCows(2)
+                .build();
+
+        String requestBody = mapper.writeValueAsString(userCommonsToSend);
+        String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+
+        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+        when(commonsRepository.findById(eq(234L))).thenReturn(Optional.of(testCommons));
+
+        // act
+        MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=234")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody)
+                .with(csrf()))
+                .andExpect(status().is(404)).andReturn();
+
+        // assert
+
+        String responseString = response.getResponse().getContentAsString();
+        String expectedString = "{\"message\":\"UserCommons with commonsId 234 and userId 1 not found\",\"type\":\"EntityNotFoundException\"}";
+        Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
+        Map<String, Object> jsonResponse = responseToJson(response);
+        assertEquals(expectedJson, jsonResponse);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_SellCow_commons_for_usercommons_DOES_NOT_exist() throws Exception {
+
+        // arrange
+
+        UserCommons origUserCommons = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(1)
+                .build();
+
+        Commons testCommons = Commons
+                .builder()
+                .id(234L)
+                .name("test commons")
+                .cowPrice(10)
+                .milkPrice(2)
+                .startingBalance(300)
+                .startingDate(LocalDateTime.now())
+                .build();
+
+        UserCommons userCommonsToSend = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(1)
+                .build();
+
+        UserCommons correctuserCommons = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300 + testCommons.getCowPrice())
+                .numOfCows(2)
+                .build();
+
+        String requestBody = mapper.writeValueAsString(userCommonsToSend);
+        String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+
+        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+        when(commonsRepository.findById(eq(234L))).thenReturn(Optional.of(testCommons));
+
+        // act
+        MvcResult response = mockMvc.perform(put("/api/usercommons/sell?commonsId=234")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody)
+                .with(csrf()))
+                .andExpect(status().is(404)).andReturn();
+
+        // assert
+        String responseString = response.getResponse().getContentAsString();
+        String expectedString = "{\"message\":\"UserCommons with commonsId 234 and userId 1 not found\",\"type\":\"EntityNotFoundException\"}";
+        Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
+        Map<String, Object> jsonResponse = responseToJson(response);
+        assertEquals(expectedJson, jsonResponse);
+    }
+
+    // tests for when the common itself doesn't exist
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_SellCow_commons_DOES_NOT_exist() throws Exception {
+
+        // arrange
+
+        UserCommons origUserCommons = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(1)
+                .build();
+
+        Commons testCommons = Commons
+                .builder()
+                .name("test commons")
+                .cowPrice(10)
+                .milkPrice(2)
+                .startingBalance(300)
+                .startingDate(LocalDateTime.now())
+                .build();
+
+        UserCommons userCommonsToSend = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(1)
+                .build();
+
+        UserCommons correctuserCommons = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300 + testCommons.getCowPrice())
+                .numOfCows(2)
+                .build();
+
+        String requestBody = mapper.writeValueAsString(userCommonsToSend);
+        String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+
+        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+        when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
+
+        // act
+        MvcResult response = mockMvc.perform(put("/api/usercommons/sell?commonsId=222")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody)
+                .with(csrf()))
+                .andExpect(status().is(404)).andReturn();
+
+        // assert
+        String responseString = response.getResponse().getContentAsString();
+        String expectedString = "{\"message\":\"Commons with id 222 not found\",\"type\":\"EntityNotFoundException\"}";
+        Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
+        Map<String, Object> jsonResponse = responseToJson(response);
+        assertEquals(expectedJson, jsonResponse);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_BuyCow_commons_DOES_NOT_exist() throws Exception {
+
+        // arrange
+
+        UserCommons origUserCommons = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(1)
+                .build();
+
+        Commons testCommons = Commons
+                .builder()
+                .name("test commons")
+                .cowPrice(10)
+                .milkPrice(2)
+                .startingBalance(300)
+                .startingDate(LocalDateTime.now())
+                .build();
+
+        UserCommons userCommonsToSend = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(1)
+                .build();
+
+        UserCommons correctuserCommons = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300 + testCommons.getCowPrice())
+                .numOfCows(2)
+                .build();
+
+        String requestBody = mapper.writeValueAsString(userCommonsToSend);
+        String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+
+        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+        when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
+
+        // act
+        MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=222")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody)
+                .with(csrf()))
+                .andExpect(status().is(404)).andReturn();
+
+        // assert
+        String responseString = response.getResponse().getContentAsString();
+        String expectedString = "{\"message\":\"Commons with id 222 not found\",\"type\":\"EntityNotFoundException\"}";
+        Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
+        Map<String, Object> jsonResponse = responseToJson(response);
+        assertEquals(expectedJson, jsonResponse);
+    }
+
+    // Put tests for edge cases (not enough money to buy, or no cow to sell)
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_BuyCow_commons_exists_not_enough_money() throws Exception {
+
+        // arrange
+
+        UserCommons origUserCommons = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(0)
+                .numOfCows(1)
+                .build();
+
+        Commons testCommons = Commons
+                .builder()
+                .name("test commons")
+                .cowPrice(10)
+                .milkPrice(2)
+                .startingBalance(0)
+                .startingDate(LocalDateTime.now())
+                .build();
+
+        UserCommons userCommonsToSend = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(0)
+                .numOfCows(1)
+                .build();
+
+        UserCommons correctuserCommons = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(0)
+                .numOfCows(1)
+                .build();
+
+        String requestBody = mapper.writeValueAsString(userCommonsToSend);
+        String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+
+        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+        when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
+
+        // act
+        MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody)
+                .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
+        verify(userCommonsRepository, times(1)).save(correctuserCommons);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedReturn, responseString);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_SellCow_commons_exists_no_cow_to_sell() throws Exception {
+
+        // arrange
+
+        UserCommons origUserCommons = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(0)
+                .build();
+
+        Commons testCommons = Commons
+                .builder()
+                .name("test commons")
+                .cowPrice(10)
+                .milkPrice(2)
+                .startingBalance(300)
+                .startingDate(LocalDateTime.now())
+                .build();
+
+        UserCommons userCommonsToSend = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(0)
+                .build();
+
+        UserCommons correctuserCommons = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(0)
+                .build();
+
+        String requestBody = mapper.writeValueAsString(userCommonsToSend);
+        String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+
+        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+        when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
+
+        // act
+        MvcResult response = mockMvc.perform(put("/api/usercommons/sell?commonsId=1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody)
+                .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
+        verify(userCommonsRepository, times(1)).save(correctuserCommons);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedReturn, responseString);
+    }
 
     @WithMockUser(roles = { "USER" })
     @Test
     public void test_getAllUserCommonsById_exists() throws Exception {
         List<UserCommons> expectedUserCommons = new ArrayList<UserCommons>();
-      UserCommons testexpectedUserCommons = dummyUserCommons(1);
-      expectedUserCommons.add(testexpectedUserCommons);
-      when(userCommonsRepository.findByCommonsId(eq(1L))).thenReturn(expectedUserCommons);
-  
-      MvcResult response = mockMvc.perform(get("/api/usercommons/commons/all?commonsId=1"))
-          .andExpect(status().isOk()).andReturn();
-  
-      verify(userCommonsRepository, times(1)).findByCommonsId(eq(1L));
-  
-      String expectedJson = mapper.writeValueAsString(expectedUserCommons);
-      String responseString = response.getResponse().getContentAsString();
-  
-      assertEquals(expectedJson, responseString);
+        UserCommons testexpectedUserCommons = dummyUserCommons(1);
+        expectedUserCommons.add(testexpectedUserCommons);
+        when(userCommonsRepository.findByCommonsId(eq(1L))).thenReturn(expectedUserCommons);
+
+        MvcResult response = mockMvc.perform(get("/api/usercommons/commons/all?commonsId=1"))
+                .andExpect(status().isOk()).andReturn();
+
+        verify(userCommonsRepository, times(1)).findByCommonsId(eq(1L));
+
+        String expectedJson = mapper.writeValueAsString(expectedUserCommons);
+        String responseString = response.getResponse().getContentAsString();
+
+        assertEquals(expectedJson, responseString);
     }
 
     @WithMockUser(roles = { "ADMIN" })
     @Test
     public void test_Admin_getAllUserCommonsById_exists() throws Exception {
         List<UserCommons> expectedUserCommons = new ArrayList<UserCommons>();
-      UserCommons testexpectedUserCommons = dummyUserCommons(1);
-      expectedUserCommons.add(testexpectedUserCommons);
-      when(userCommonsRepository.findByCommonsId(eq(1L))).thenReturn(expectedUserCommons);
-  
-      MvcResult response = mockMvc.perform(get("/api/usercommons/commons/all?commonsId=1"))
-          .andExpect(status().isOk()).andReturn();
-  
-      verify(userCommonsRepository, times(1)).findByCommonsId(eq(1L));
-  
-      String expectedJson = mapper.writeValueAsString(expectedUserCommons);
-      String responseString = response.getResponse().getContentAsString();
-  
-      assertEquals(expectedJson, responseString);
+        UserCommons testexpectedUserCommons = dummyUserCommons(1);
+        expectedUserCommons.add(testexpectedUserCommons);
+        when(userCommonsRepository.findByCommonsId(eq(1L))).thenReturn(expectedUserCommons);
+
+        MvcResult response = mockMvc.perform(get("/api/usercommons/commons/all?commonsId=1"))
+                .andExpect(status().isOk()).andReturn();
+
+        verify(userCommonsRepository, times(1)).findByCommonsId(eq(1L));
+
+        String expectedJson = mapper.writeValueAsString(expectedUserCommons);
+        String responseString = response.getResponse().getContentAsString();
+
+        assertEquals(expectedJson, responseString);
     }
 }


### PR DESCRIPTION
## Overview

1) when a user joins a commons, the UserCommon's repository now saves a username parameter that is the current user's google full name (this can be easily changed to email, firstname, or last name).
2) a username column was added to the leaderboard page that displays all users in common with their username from (1).

## Changes

### Backend

- UserCommons.java: added username to UserCommons
- CommonsController.java: username gets initialized as current user's name, UserCommons gets built when a player joins
- UserCommonsControllerTests.java: updated all tests
- CommonsControllerTests.java: updated all tests

### Frontend

- LeaderboardTable.js : added the username column to the table
- LeaderboardTable.test.js: updated all tests
- leaderboardFixtures.js: updated fixtures
