### PR TITLE
IL - After Carrying Capacity added to backend (issue #13), add it to the frontend Create / Update operations

### DIFF
--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -140,6 +140,25 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
       </Form.Group>
 
       <Form.Group className="mb-3">
+        <Form.Label htmlFor="carryingCapacity">Carrying Capacity</Form.Label>
+        <Form.Control
+          data-testid={`${testid}-carryingCapacity`}
+          id="carryingCapacity"
+          type="number"
+          step="1"
+          isInvalid={!!errors.carryingCapacity}
+          {...register("carryingCapacity", {
+            valueAsNumber: true,
+            required: "Carrying Capacity is required",
+            min: { value: 0.00, message: "Carrying Capacity must be positive" },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.carryingCapacity?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
         <Form.Label htmlFor="showLeaderboard">Show Leaderboard?</Form.Label>
         <Form.Check 
           data-testid={`${testid}-showLeaderboard`}

--- a/frontend/src/main/pages/AdminEditCommonsPage.js
+++ b/frontend/src/main/pages/AdminEditCommonsPage.js
@@ -36,6 +36,7 @@ export default function CommonsEditPage() {
         "startingDate": commons.startingDate,
         "degradationRate": commons.degradationRate,
         "showLeaderboard": commons.showLeaderboard,
+        "carryingCapacity": commons.carryingCapacity,
     }
   });
 

--- a/frontend/src/tests/pages/AdminCreateCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminCreateCommonsPage.test.js
@@ -60,7 +60,8 @@ describe("AdminCreateCommonsPage tests", () => {
             "startingBalance": 500,
             "startingDate": "2022-03-05T00:00:00",
             "degradationRate": 30.4,
-            "showLeaderboard": false
+            "showLeaderboard": false,
+            "carryingCapacity": 100
         });
 
         render(
@@ -79,6 +80,7 @@ describe("AdminCreateCommonsPage tests", () => {
         const milkPriceField = screen.getByLabelText("Milk Price");
         const startDateField = screen.getByLabelText("Starting Date");
         const degradationRateField = screen.getByLabelText("Degradation Rate");
+        const carryingCapacityField = screen.getByLabelText("Carrying Capacity");
         const showLeaderboardField = screen.getByLabelText("Show Leaderboard?");
         const button = screen.getByTestId("CommonsForm-Submit-Button");
 
@@ -88,6 +90,7 @@ describe("AdminCreateCommonsPage tests", () => {
         fireEvent.change(milkPriceField, { target: { value: '5' } })
         fireEvent.change(startDateField, { target: { value: '2022-03-05' } })
         fireEvent.change(degradationRateField, { target: { value: '30.4' } })
+        fireEvent.change(carryingCapacityField, {target: { value: '50'}})
         fireEvent.change(showLeaderboardField, { target: { value: true } })
         fireEvent.click(button);
 
@@ -104,7 +107,8 @@ describe("AdminCreateCommonsPage tests", () => {
             milkPrice: 5,
             startingDate: '2022-03-05T00:00:00.000Z', // [1]
             degradationRate: 30.4,
-            showLeaderboard: false
+            carryingCapacity: 50,
+            showLeaderboard: false,
         };
 
         expect(axiosMock.history.post[0].data).toEqual( JSON.stringify(expectedCommons) );

--- a/frontend/src/tests/pages/AdminEditCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminEditCommonsPage.test.js
@@ -49,6 +49,7 @@ describe("AdminEditCommonsPage tests", () => {
                 "milkPrice": 10,
                 "degradationRate": 20.3,
                 "showLeaderboard": false,
+                "carryingCapacity": 100,
             });
             axiosMock.onPut('/api/commons/update').reply(200, {
                 "id": 5,
@@ -59,6 +60,7 @@ describe("AdminEditCommonsPage tests", () => {
                 "milkPrice": 5,
                 "degradationRate": 40.3,
                 "showLeaderboard": false,
+                "carryingCapacity": 50,
             });
         });
 
@@ -90,6 +92,7 @@ describe("AdminEditCommonsPage tests", () => {
             const milkPriceField = screen.getByLabelText(/Milk Price/);
             const startingDateField = screen.getByLabelText(/Starting Date/);
             const degradationRateField = screen.getByLabelText(/Degradation Rate/);
+            const carryingCapacityField = screen.getByLabelText(/Carrying Capacity/);
             const showLeaderboardField = screen.getByLabelText(/Show Leaderboard\?/);
 
             expect(nameField).toHaveValue("Seths Common");
@@ -98,6 +101,7 @@ describe("AdminEditCommonsPage tests", () => {
             expect(cowPriceField).toHaveValue(15);
             expect(milkPriceField).toHaveValue(10);
             expect(degradationRateField).toHaveValue(20.3);
+            expect(carryingCapacityField).toHaveValue(100);
             expect(showLeaderboardField).not.toBeChecked();
         });
 
@@ -118,6 +122,7 @@ describe("AdminEditCommonsPage tests", () => {
             const milkPriceField = screen.getByLabelText(/Milk Price/);
             const startingDateField = screen.getByLabelText(/Starting Date/);
             const degradationRateField = screen.getByLabelText(/Degradation Rate/);
+            const carryingCapacityField = screen.getByLabelText(/Carrying Capacity/);
             const showLeaderboardField = screen.getByLabelText(/Show Leaderboard\?/);
 
             expect(nameField).toHaveValue("Seths Common");
@@ -126,6 +131,7 @@ describe("AdminEditCommonsPage tests", () => {
             expect(cowPriceField).toHaveValue(15);
             expect(milkPriceField).toHaveValue(10);
             expect(degradationRateField).toHaveValue(20.3);
+            expect(carryingCapacityField).toHaveValue(100);
             expect(showLeaderboardField).not.toBeChecked();
 
             const submitButton = screen.getByText("Update");
@@ -138,6 +144,7 @@ describe("AdminEditCommonsPage tests", () => {
             fireEvent.change(cowPriceField, { target: { value: 200 } })
             fireEvent.change(milkPriceField, { target: { value: 5 } })
             fireEvent.change(degradationRateField, { target: { value: 40.3 } })
+            fireEvent.change(carryingCapacityField, { target: { value: 50 }})
             fireEvent.click(showLeaderboardField)
 
             fireEvent.click(submitButton);
@@ -156,6 +163,7 @@ describe("AdminEditCommonsPage tests", () => {
                 "startingDate": "2022-03-07T00:00:00.000Z",
                 "degradationRate": 40.3,
                 "showLeaderboard": true,
+                "carryingCapacity": 50,
             })); // posted object
         });
     });

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -118,6 +118,7 @@ public class CommonsController extends ApiController {
     updated.setStartingDate(params.getStartingDate());
     updated.setEndingDate(params.getEndingDate());
     updated.setShowLeaderboard(params.getShowLeaderboard());
+    updated.setCarryingCapacity(params.getCarryingCapacity());
     updated.setDegradationRate(params.getDegradationRate()); 
 
     if(params.getDegradationRate() < 0){

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -103,6 +103,14 @@ public class CommonsController extends ApiController {
     Commons updated;
     HttpStatus status;
 
+    if(params.getDegradationRate() < 0){
+      throw new IllegalArgumentException("Degradation Rate cannot be negative");
+    }
+
+    if(params.getCarryingCapacity() < 0){
+      throw new IllegalArgumentException("Degradation Rate cannot be negative");
+    }
+
     if (existing.isPresent()) {
       updated = existing.get();
       status = HttpStatus.NO_CONTENT;
@@ -120,11 +128,6 @@ public class CommonsController extends ApiController {
     updated.setShowLeaderboard(params.getShowLeaderboard());
     updated.setCarryingCapacity(params.getCarryingCapacity());
     updated.setDegradationRate(params.getDegradationRate()); 
-
-    if(params.getDegradationRate() < 0){
-      throw new IllegalArgumentException("Degradation Rate cannot be negative");
-    }
-    
 
     commonsRepository.save(updated);
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -107,8 +107,8 @@ public class CommonsController extends ApiController {
       throw new IllegalArgumentException("Degradation Rate cannot be negative");
     }
 
-    if(params.getCarryingCapacity() < 0){
-      throw new IllegalArgumentException("Carrying Capacity cannot be negative");
+    if(params.getCarryingCapacity() <= 0){
+      throw new IllegalArgumentException("Carrying Capacity must be strictly >0");
     }
 
     if (existing.isPresent()) {

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -117,7 +117,6 @@ public class CommonsController extends ApiController {
     updated.setStartingBalance(params.getStartingBalance());
     updated.setStartingDate(params.getStartingDate());
     updated.setEndingDate(params.getEndingDate());
-    updated.setCarryingCapacity(params.getCarryingCapacity());
     updated.setShowLeaderboard(params.getShowLeaderboard());
     updated.setDegradationRate(params.getDegradationRate()); 
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -108,7 +108,7 @@ public class CommonsController extends ApiController {
     }
 
     if(params.getCarryingCapacity() < 0){
-      throw new IllegalArgumentException("Degradation Rate cannot be negative");
+      throw new IllegalArgumentException("Carrying Capacity cannot be negative");
     }
 
     if (existing.isPresent()) {

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
@@ -12,9 +12,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.NumberFormat;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import org.springframework.security.core.GrantedAuthority;
 
-import edu.ucsb.cs156.happiercows.entities.User;
 
 @Data
 @AllArgsConstructor

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,405 +48,450 @@ import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 @AutoConfigureDataJpa
 public class CommonsControllerTests extends ControllerTestCase {
 
-  @MockBean
-  UserCommonsRepository userCommonsRepository;
-
-  @MockBean
-  UserRepository userRepository;
-
-  @MockBean
-  CommonsRepository commonsRepository;
-
-  @Autowired
-  private ObjectMapper objectMapper;
-
-  private LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
-  private LocalDateTime someOtherTime = LocalDateTime.parse("2022-04-20T15:50:10");
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void createCommonsTest() throws Exception {
-
-    Commons commons = Commons.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .endingDate(someOtherTime)
-        .degradationRate(50.0)
-        .showLeaderboard(false)
-        .carryingCapacity(100)
-        .build();
-
-    CreateCommonsParams parameters = CreateCommonsParams.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .endingDate(someOtherTime)
-        .degradationRate(50.0)
-        .showLeaderboard(false)
-        .carryingCapacity(100)
-        .build();
-
-    String requestBody = objectMapper.writeValueAsString(parameters);
-    String expectedResponse = objectMapper.writeValueAsString(commons);
-
-    when(commonsRepository.save(commons))
-        .thenReturn(commons);
-
-    MvcResult response = mockMvc
-        .perform(post("/api/commons/new").with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8")
-            .content(requestBody))
-        .andExpect(status().isOk())
-        .andReturn();
-
-    verify(commonsRepository, times(1)).save(commons);
-
-    String actualResponse = response.getResponse().getContentAsString();
-    assertEquals(expectedResponse, actualResponse);
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void createCommonsTest_zeroDegradation() throws Exception {
-
-    Commons commons = Commons.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(0)
-        .endingDate(someOtherTime)
-        .showLeaderboard(false)
-        .carryingCapacity(100)
-        .build();
-
-    CreateCommonsParams parameters = CreateCommonsParams.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(0)
-        .endingDate(someOtherTime)
-        .showLeaderboard(false)
-        .carryingCapacity(100)
-        .build();
-
-    String requestBody = objectMapper.writeValueAsString(parameters);
-    String expectedResponse = objectMapper.writeValueAsString(commons);
-
-    when(commonsRepository.save(commons))
-        .thenReturn(commons);
-
-    MvcResult response = mockMvc
-        .perform(post("/api/commons/new").with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8")
-            .content(requestBody))
-        .andExpect(status().isOk())
-        .andReturn();
-
-    verify(commonsRepository, times(1)).save(commons);
-
-    String actualResponse = response.getResponse().getContentAsString();
-    assertEquals(expectedResponse, actualResponse);
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void createCommonsTest_withIllegalDegradationRate() throws Exception {
-
-    Commons commons = Commons.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(-8.49)
-        .carryingCapacity(100)
-        .build();
-
-    CreateCommonsParams parameters = CreateCommonsParams.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(-8.49)
-        .carryingCapacity(100)
-        .build();
-
-    String requestBody = objectMapper.writeValueAsString(parameters);
-
-    when(commonsRepository.save(commons))
-        .thenReturn(commons);
-
-    MvcResult response = mockMvc
-        .perform(post("/api/commons/new").with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8")
-            .content(requestBody))
-        .andExpect(status().isBadRequest()).andReturn();
-
-    Optional<IllegalArgumentException> someException = Optional
-        .ofNullable((IllegalArgumentException) response.getResolvedException());
-
-    assertNotNull(someException.get());
-    assertTrue(someException.get() instanceof IllegalArgumentException);
-  }
-
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void getCommonsTest() throws Exception {
-    List<Commons> expectedCommons = new ArrayList<Commons>();
-    Commons Commons1 = Commons.builder().name("TestCommons1").build();
-
-    expectedCommons.add(Commons1);
-    when(commonsRepository.findAll()).thenReturn(expectedCommons);
-    MvcResult response = mockMvc.perform(get("/api/commons/all").contentType("application/json"))
-        .andExpect(status().isOk()).andReturn();
-
-    verify(commonsRepository, times(1)).findAll();
-
-    String responseString = response.getResponse().getContentAsString();
-    List<Commons> actualCommons = objectMapper.readValue(responseString, new TypeReference<List<Commons>>() {
-    });
-    assertEquals(actualCommons, expectedCommons);
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void updateCommonsTest() throws Exception {
-
-    CreateCommonsParams parameters = CreateCommonsParams.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .endingDate(someOtherTime)
-        .degradationRate(50.0)
-        .showLeaderboard(true)
-        .carryingCapacity(100)
-        .build();
-
-    Commons commons = Commons.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .endingDate(someOtherTime)
-        .degradationRate(50.0)
-        .showLeaderboard(true)
-        .carryingCapacity(100)
-        .build();
-
-    String requestBody = objectMapper.writeValueAsString(parameters);
-
-    when(commonsRepository.save(commons))
-        .thenReturn(commons);
-
-    mockMvc
-        .perform(put("/api/commons/update?id=0").with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8")
-            .content(requestBody))
-        .andExpect(status().isCreated());
-
-    verify(commonsRepository, times(1)).save(commons);
-
-    parameters.setMilkPrice(parameters.getMilkPrice() + 3.00);
-    commons.setMilkPrice(parameters.getMilkPrice());
-
-    parameters.setDegradationRate(parameters.getDegradationRate() + 1.00);
-    commons.setDegradationRate(parameters.getDegradationRate());
-
-    parameters.setShowLeaderboard(false);
-    commons.setShowLeaderboard(parameters.getShowLeaderboard());
-
-    parameters.setCarryingCapacity(parameters.getCarryingCapacity() + 1);
-    commons.setCarryingCapacity(parameters.getCarryingCapacity());
-
-    requestBody = objectMapper.writeValueAsString(parameters);
-
-    when(commonsRepository.findById(0L))
-        .thenReturn(Optional.of(commons));
-
-    when(commonsRepository.save(commons))
-        .thenReturn(commons);
-
-    mockMvc
-        .perform(put("/api/commons/update?id=0").with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8")
-            .content(requestBody))
-        .andExpect(status().isNoContent());
-
-    verify(commonsRepository, times(1)).save(commons);
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void updateCommonsTest_withDegradationRate_Zero() throws Exception {
-
-    CreateCommonsParams parameters = CreateCommonsParams.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(8.49)
-        .endingDate(someOtherTime)
-        .showLeaderboard(false)
-        .carryingCapacity(100)
-        .build();
-
-    Commons commons = Commons.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(8.49)
-        .endingDate(someOtherTime)
-        .showLeaderboard(false)
-        .carryingCapacity(100)
-        .build();
-
-    String requestBody = objectMapper.writeValueAsString(parameters);
-
-    when(commonsRepository.save(commons))
-        .thenReturn(commons);
-
-    mockMvc
-        .perform(put("/api/commons/update?id=0").with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8")
-            .content(requestBody))
-        .andExpect(status().isCreated());
-
-    verify(commonsRepository, times(1)).save(commons);
-
-    parameters.setMilkPrice(parameters.getMilkPrice() + 3.00);
-    commons.setMilkPrice(parameters.getMilkPrice());
-    parameters.setDegradationRate(0);
-    commons.setDegradationRate(parameters.getDegradationRate());
-
-    requestBody = objectMapper.writeValueAsString(parameters);
-
-    when(commonsRepository.findById(0L))
-        .thenReturn(Optional.of(commons));
-
-    when(commonsRepository.save(commons))
-        .thenReturn(commons);
-
-    mockMvc
-        .perform(put("/api/commons/update?id=0").with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8")
-            .content(requestBody))
-        .andExpect(status().isNoContent());
-
-    verify(commonsRepository, times(1)).save(commons);
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void updateCommonsTest_withIllegalCarryingCapacity() throws Exception {
-
-    CreateCommonsParams parameters = CreateCommonsParams.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(8.49)
-        .showLeaderboard(false)
-        .carryingCapacity(-100)
-        .build();
-
-    String requestBody = objectMapper.writeValueAsString(parameters);
-
-    MvcResult response = mockMvc
-        .perform(put("/api/commons/update?id=0").with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8")
-            .content(requestBody))
-        .andExpect(status().isBadRequest()).andReturn();
-
-    Optional<IllegalArgumentException> someException = Optional
-        .ofNullable((IllegalArgumentException) response.getResolvedException());
-
-    assertNotNull(someException.get());
-    assertTrue(someException.get() instanceof IllegalArgumentException);
-    assertEquals("Carrying Capacity cannot be negative", someException.get().getMessage());
-  }
-
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void updateCommonsTest_withIllegalDegradationRate() throws Exception {
-
-    CreateCommonsParams parameters = CreateCommonsParams.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(-20)
-        .showLeaderboard(false)
-        .carryingCapacity(100)
-        .build();
-
-    String requestBody = objectMapper.writeValueAsString(parameters);
-
-    MvcResult response = mockMvc
-        .perform(put("/api/commons/update?id=0").with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8")
-            .content(requestBody))
-        .andExpect(status().isBadRequest()).andReturn();
-
-    Optional<IllegalArgumentException> someException = Optional
-        .ofNullable((IllegalArgumentException) response.getResolvedException());
-
-    assertNotNull(someException.get());
-    assertTrue(someException.get() instanceof IllegalArgumentException);
-    assertEquals("Degradation Rate cannot be negative", someException.get().getMessage());
-
-  }
-
-
-
-  // This common SHOULD be in the repository
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void getCommonsByIdTest_valid() throws Exception {
-    Commons Commons1 = Commons.builder()
-        .name("TestCommons2")
-        .id(18L)
-        .build();
-
-    when(commonsRepository.findById(eq(18L))).thenReturn(Optional.of(Commons1));
-
-    MvcResult response = mockMvc.perform(get("/api/commons?id=18"))
-        .andExpect(status().isOk()).andReturn();
-
-    verify(commonsRepository, times(1)).findById(eq(18L));
-    String expectedJson = mapper.writeValueAsString(Commons1);
-    String responseString = response.getResponse().getContentAsString();
-    assertEquals(expectedJson, responseString);
-  }
-
-  // This common SHOULD NOT be in the repository
+    @MockBean
+    UserCommonsRepository userCommonsRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    @MockBean
+    CommonsRepository commonsRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+    private LocalDateTime someOtherTime = LocalDateTime.parse("2022-04-20T15:50:10");
+    private Commons jacksonsCommons = Commons.builder()
+            .name("Jackson's Commons")
+            .cowPrice(500.99)
+            .milkPrice(8.99)
+            .startingBalance(1020.10)
+            .startingDate(someTime)
+            .endingDate(someOtherTime)
+            .degradationRate(50.0)
+            .showLeaderboard(false)
+            .carryingCapacity(100)
+            .build();
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void createCommonsTest() throws Exception {
+
+        Commons commons = Commons.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .endingDate(someOtherTime)
+                .degradationRate(50.0)
+                .showLeaderboard(false)
+                .carryingCapacity(100)
+                .build();
+
+        CreateCommonsParams parameters = CreateCommonsParams.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .endingDate(someOtherTime)
+                .degradationRate(50.0)
+                .showLeaderboard(false)
+                .carryingCapacity(100)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(parameters);
+        String expectedResponse = objectMapper.writeValueAsString(commons);
+
+        when(commonsRepository.save(commons))
+                .thenReturn(commons);
+
+        MvcResult response = mockMvc
+                .perform(post("/api/commons/new").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        verify(commonsRepository, times(1)).save(commons);
+
+        String actualResponse = response.getResponse().getContentAsString();
+        assertEquals(expectedResponse, actualResponse);
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void createCommonsTest_zeroDegradation() throws Exception {
+
+        Commons commons = Commons.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(0)
+                .endingDate(someOtherTime)
+                .showLeaderboard(false)
+                .carryingCapacity(100)
+                .build();
+
+        CreateCommonsParams parameters = CreateCommonsParams.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(0)
+                .endingDate(someOtherTime)
+                .showLeaderboard(false)
+                .carryingCapacity(100)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(parameters);
+        String expectedResponse = objectMapper.writeValueAsString(commons);
+
+        when(commonsRepository.save(commons))
+                .thenReturn(commons);
+
+        MvcResult response = mockMvc
+                .perform(post("/api/commons/new").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        verify(commonsRepository, times(1)).save(commons);
+
+        String actualResponse = response.getResponse().getContentAsString();
+        assertEquals(expectedResponse, actualResponse);
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void createCommonsTest_withIllegalDegradationRate() throws Exception {
+
+        Commons commons = Commons.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(-8.49)
+                .carryingCapacity(100)
+                .build();
+
+        CreateCommonsParams parameters = CreateCommonsParams.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(-8.49)
+                .carryingCapacity(100)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(parameters);
+
+        when(commonsRepository.save(commons))
+                .thenReturn(commons);
+
+        MvcResult response = mockMvc
+                .perform(post("/api/commons/new").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isBadRequest()).andReturn();
+
+        Optional<IllegalArgumentException> someException = Optional
+                .ofNullable((IllegalArgumentException) response.getResolvedException());
+
+        assertNotNull(someException.get());
+        assertTrue(someException.get() instanceof IllegalArgumentException);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void getCommonsTest() throws Exception {
+        List<Commons> expectedCommons = new ArrayList<Commons>();
+        Commons Commons1 = Commons.builder().name("TestCommons1").build();
+
+        expectedCommons.add(Commons1);
+        when(commonsRepository.findAll()).thenReturn(expectedCommons);
+        MvcResult response = mockMvc.perform(get("/api/commons/all").contentType("application/json"))
+                .andExpect(status().isOk()).andReturn();
+
+        verify(commonsRepository, times(1)).findAll();
+
+        String responseString = response.getResponse().getContentAsString();
+        List<Commons> actualCommons = objectMapper.readValue(responseString, new TypeReference<List<Commons>>() {
+        });
+        assertEquals(actualCommons, expectedCommons);
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void updateCommonsTest() throws Exception {
+
+        CreateCommonsParams parameters = CreateCommonsParams.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .endingDate(someOtherTime)
+                .degradationRate(50.0)
+                .showLeaderboard(true)
+                .carryingCapacity(100)
+                .build();
+
+        Commons commons = Commons.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .endingDate(someOtherTime)
+                .degradationRate(50.0)
+                .showLeaderboard(true)
+                .carryingCapacity(100)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(parameters);
+
+        when(commonsRepository.save(commons))
+                .thenReturn(commons);
+
+        mockMvc
+                .perform(put("/api/commons/update?id=0").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isCreated());
+
+        verify(commonsRepository, times(1)).save(commons);
+
+        parameters.setMilkPrice(parameters.getMilkPrice() + 3.00);
+        commons.setMilkPrice(parameters.getMilkPrice());
+
+        parameters.setDegradationRate(parameters.getDegradationRate() + 1.00);
+        commons.setDegradationRate(parameters.getDegradationRate());
+
+        parameters.setShowLeaderboard(false);
+        commons.setShowLeaderboard(parameters.getShowLeaderboard());
+
+        parameters.setCarryingCapacity(parameters.getCarryingCapacity() + 1);
+        commons.setCarryingCapacity(parameters.getCarryingCapacity());
+
+        requestBody = objectMapper.writeValueAsString(parameters);
+
+        when(commonsRepository.findById(0L))
+                .thenReturn(Optional.of(commons));
+
+        when(commonsRepository.save(commons))
+                .thenReturn(commons);
+
+        mockMvc
+                .perform(put("/api/commons/update?id=0").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isNoContent());
+
+        verify(commonsRepository, times(1)).save(commons);
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void updateCommonsTest_withDegradationRate_Zero() throws Exception {
+
+        CreateCommonsParams parameters = CreateCommonsParams.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(8.49)
+                .endingDate(someOtherTime)
+                .showLeaderboard(false)
+                .carryingCapacity(100)
+                .build();
+
+        Commons commons = Commons.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(8.49)
+                .endingDate(someOtherTime)
+                .showLeaderboard(false)
+                .carryingCapacity(100)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(parameters);
+
+        when(commonsRepository.save(commons))
+                .thenReturn(commons);
+
+        mockMvc
+                .perform(put("/api/commons/update?id=0").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isCreated());
+
+        verify(commonsRepository, times(1)).save(commons);
+
+        parameters.setMilkPrice(parameters.getMilkPrice() + 3.00);
+        commons.setMilkPrice(parameters.getMilkPrice());
+        parameters.setDegradationRate(0);
+        commons.setDegradationRate(parameters.getDegradationRate());
+
+        requestBody = objectMapper.writeValueAsString(parameters);
+
+        when(commonsRepository.findById(0L))
+                .thenReturn(Optional.of(commons));
+
+        when(commonsRepository.save(commons))
+                .thenReturn(commons);
+
+        mockMvc
+                .perform(put("/api/commons/update?id=0").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isNoContent());
+
+        verify(commonsRepository, times(1)).save(commons);
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void updateCommonsTest_withNegativeCarryingCapacity() throws Exception {
+
+        CreateCommonsParams parameters = CreateCommonsParams.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(8.49)
+                .showLeaderboard(false)
+                .carryingCapacity(-100)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(parameters);
+
+        when(commonsRepository.findById(0L)).thenReturn(Optional.of(jacksonsCommons));
+
+        MvcResult response = mockMvc
+                .perform(put("/api/commons/update?id=0").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isBadRequest()).andReturn();
+
+        Optional<IllegalArgumentException> someException = Optional
+                .ofNullable((IllegalArgumentException) response.getResolvedException());
+
+        assertNotNull(someException.get());
+        assertTrue(someException.get() instanceof IllegalArgumentException);
+        assertEquals("Carrying Capacity must be strictly >0", someException.get().getMessage());
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void updateCommonsTest_withZeroCarryingCapacity() throws Exception {
+
+        CreateCommonsParams parameters = CreateCommonsParams.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(8.49)
+                .showLeaderboard(false)
+                .carryingCapacity(0)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(parameters);
+
+        when(commonsRepository.findById(0L)).thenReturn(Optional.of(jacksonsCommons));
+
+        MvcResult response = mockMvc
+                .perform(put("/api/commons/update?id=0").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isBadRequest()).andReturn();
+
+        Optional<IllegalArgumentException> someException = Optional
+                .ofNullable((IllegalArgumentException) response.getResolvedException());
+
+        assertNotNull(someException.get());
+        assertTrue(someException.get() instanceof IllegalArgumentException);
+        assertEquals("Carrying Capacity must be strictly >0", someException.get().getMessage());
+    }
+
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void updateCommonsTest_withIllegalDegradationRate() throws Exception {
+
+        CreateCommonsParams parameters = CreateCommonsParams.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(-20)
+                .showLeaderboard(false)
+                .carryingCapacity(100)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(parameters);
+
+        MvcResult response = mockMvc
+                .perform(put("/api/commons/update?id=0").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isBadRequest()).andReturn();
+
+        Optional<IllegalArgumentException> someException = Optional
+                .ofNullable((IllegalArgumentException) response.getResolvedException());
+
+        assertNotNull(someException.get());
+        assertTrue(someException.get() instanceof IllegalArgumentException);
+        assertEquals("Degradation Rate cannot be negative", someException.get().getMessage());
+
+    }
+
+    // This common SHOULD be in the repository
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void getCommonsByIdTest_valid() throws Exception {
+        Commons Commons1 = Commons.builder()
+                .name("TestCommons2")
+                .id(18L)
+                .build();
+
+        when(commonsRepository.findById(eq(18L))).thenReturn(Optional.of(Commons1));
+
+        MvcResult response = mockMvc.perform(get("/api/commons?id=18"))
+                .andExpect(status().isOk()).andReturn();
+
+        verify(commonsRepository, times(1)).findById(eq(18L));
+        String expectedJson = mapper.writeValueAsString(Commons1);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    // This common SHOULD NOT be in the repository
   @WithMockUser(roles = { "USER" })
   @Test
   public void getCommonsByIdTest_invalid() throws Exception {
@@ -465,185 +509,185 @@ public class CommonsControllerTests extends ControllerTestCase {
     assertEquals(responseMap.get("type"), "EntityNotFoundException");
   }
 
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void joinCommonsTest() throws Exception {
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void joinCommonsTest() throws Exception {
 
-    Commons c = Commons.builder()
-        .id(2L)
-        .name("Example Commons")
-        .build();
+        Commons c = Commons.builder()
+                .id(2L)
+                .name("Example Commons")
+                .build();
 
-    UserCommons uc = UserCommons.builder()
-        .userId(1L)
-        .commonsId(2L)
-        .totalWealth(0)
-        .numOfCows(0)
-        .build();
+        UserCommons uc = UserCommons.builder()
+                .userId(1L)
+                .commonsId(2L)
+                .totalWealth(0)
+                .numOfCows(0)
+                .build();
 
-    UserCommons ucSaved = UserCommons.builder()
-        .id(17L)
-        .userId(1L)
-        .commonsId(2L)
-        .totalWealth(0)
-        .numOfCows(0)
-        .build();
+        UserCommons ucSaved = UserCommons.builder()
+                .id(17L)
+                .userId(1L)
+                .commonsId(2L)
+                .totalWealth(0)
+                .numOfCows(0)
+                .build();
 
-    String requestBody = mapper.writeValueAsString(uc);
+        String requestBody = mapper.writeValueAsString(uc);
 
-    when(userCommonsRepository.findByCommonsIdAndUserId(anyLong(), anyLong())).thenReturn(Optional.empty());
-    when(userCommonsRepository.save(eq(uc))).thenReturn(ucSaved);
-    when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));
+        when(userCommonsRepository.findByCommonsIdAndUserId(anyLong(), anyLong())).thenReturn(Optional.empty());
+        when(userCommonsRepository.save(eq(uc))).thenReturn(ucSaved);
+        when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));
 
-    MvcResult response = mockMvc
-        .perform(post("/api/commons/join?commonsId=2").with(csrf()).contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8").content(requestBody))
-        .andExpect(status().isOk()).andReturn();
+        MvcResult response = mockMvc
+                .perform(post("/api/commons/join?commonsId=2").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8").content(requestBody))
+                .andExpect(status().isOk()).andReturn();
 
-    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(2L, 1L);
-    verify(userCommonsRepository, times(1)).save(uc);
+        verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(2L, 1L);
+        verify(userCommonsRepository, times(1)).save(uc);
 
-    String responseString = response.getResponse().getContentAsString();
-    String cAsJson = mapper.writeValueAsString(c);
+        String responseString = response.getResponse().getContentAsString();
+        String cAsJson = mapper.writeValueAsString(c);
 
-    assertEquals(responseString, cAsJson);
-  }
+        assertEquals(responseString, cAsJson);
+    }
 
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void already_joined_common_test() throws Exception {
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void already_joined_common_test() throws Exception {
 
-    Commons c = Commons.builder()
-        .id(2L)
-        .name("Example Commons")
-        .build();
+        Commons c = Commons.builder()
+                .id(2L)
+                .name("Example Commons")
+                .build();
 
-    UserCommons uc = UserCommons.builder()
-        .userId(1L)
-        .commonsId(2L)
-        .totalWealth(0)
-        .numOfCows(1)
-        .build();
+        UserCommons uc = UserCommons.builder()
+                .userId(1L)
+                .commonsId(2L)
+                .totalWealth(0)
+                .numOfCows(1)
+                .build();
 
-    String requestBody = mapper.writeValueAsString(uc);
+        String requestBody = mapper.writeValueAsString(uc);
 
-    // Instead of returning empty, we instead say that it already exists. We
-    // shouldn't create a new entry.
-    when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.of(uc));
-    when(userCommonsRepository.save(eq(uc))).thenReturn(uc);
+        // Instead of returning empty, we instead say that it already exists. We
+        // shouldn't create a new entry.
+        when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.of(uc));
+        when(userCommonsRepository.save(eq(uc))).thenReturn(uc);
 
-    when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));
+        when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));
 
-    MvcResult response = mockMvc
-        .perform(post("/api/commons/join?commonsId=2").with(csrf()).contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8").content(requestBody))
-        .andExpect(status().isOk()).andReturn();
+        MvcResult response = mockMvc
+                .perform(post("/api/commons/join?commonsId=2").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8").content(requestBody))
+                .andExpect(status().isOk()).andReturn();
 
-    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(2L, 1L);
+        verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(2L, 1L);
 
-    String responseString = response.getResponse().getContentAsString();
-    String cAsJson = mapper.writeValueAsString(c);
+        String responseString = response.getResponse().getContentAsString();
+        String cAsJson = mapper.writeValueAsString(c);
 
-    assertEquals(responseString, cAsJson);
-  }
+        assertEquals(responseString, cAsJson);
+    }
 
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void user_commons_exists_but_commons_doesnt_test() throws Exception {
-    UserCommons uc = UserCommons.builder()
-        .userId(1L)
-        .commonsId(2L)
-        .totalWealth(0)
-        .numOfCows(1)
-        .build();
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void user_commons_exists_but_commons_doesnt_test() throws Exception {
+        UserCommons uc = UserCommons.builder()
+                .userId(1L)
+                .commonsId(2L)
+                .totalWealth(0)
+                .numOfCows(1)
+                .build();
 
-    String requestBody = mapper.writeValueAsString(uc);
+        String requestBody = mapper.writeValueAsString(uc);
 
-    when(commonsRepository.findById(eq(2L))).thenReturn(Optional.empty());
+        when(commonsRepository.findById(eq(2L))).thenReturn(Optional.empty());
 
-    MvcResult response = mockMvc
-        .perform(post("/api/commons/join?commonsId=2").with(csrf()).contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8").content(requestBody))
-        .andExpect(status().is(404)).andReturn();
+        MvcResult response = mockMvc
+                .perform(post("/api/commons/join?commonsId=2").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8").content(requestBody))
+                .andExpect(status().is(404)).andReturn();
 
-    verify(commonsRepository, times(1)).findById(eq(2L));
+        verify(commonsRepository, times(1)).findById(eq(2L));
 
-    Map<String, Object> responseMap = responseToJson(response);
+        Map<String, Object> responseMap = responseToJson(response);
 
-    assertEquals(responseMap.get("message"), "Commons with id 2 not found");
-    assertEquals(responseMap.get("type"), "EntityNotFoundException");
-  }
+        assertEquals(responseMap.get("message"), "Commons with id 2 not found");
+        assertEquals(responseMap.get("type"), "EntityNotFoundException");
+    }
 
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void join_and_create_userCommons_for_nonexistent_commons() throws Exception {
-    UserCommons uc = UserCommons.builder()
-        .userId(1L)
-        .commonsId(2L)
-        .totalWealth(0)
-        .numOfCows(1)
-        .build();
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void join_and_create_userCommons_for_nonexistent_commons() throws Exception {
+        UserCommons uc = UserCommons.builder()
+                .userId(1L)
+                .commonsId(2L)
+                .totalWealth(0)
+                .numOfCows(1)
+                .build();
 
-    UserCommons ucSaved = UserCommons.builder()
-        .id(17L)
-        .userId(1L)
-        .commonsId(2L)
-        .totalWealth(0)
-        .numOfCows(1)
-        .build();
+        UserCommons ucSaved = UserCommons.builder()
+                .id(17L)
+                .userId(1L)
+                .commonsId(2L)
+                .totalWealth(0)
+                .numOfCows(1)
+                .build();
 
-    String requestBody = mapper.writeValueAsString(uc);
+        String requestBody = mapper.writeValueAsString(uc);
 
-    when(commonsRepository.findById(eq(2L))).thenReturn(Optional.empty());
+        when(commonsRepository.findById(eq(2L))).thenReturn(Optional.empty());
 
-    MvcResult response = mockMvc
-        .perform(post("/api/commons/join?commonsId=2").with(csrf()).contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8").content(requestBody))
-        .andExpect(status().is(404)).andReturn();
+        MvcResult response = mockMvc
+                .perform(post("/api/commons/join?commonsId=2").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8").content(requestBody))
+                .andExpect(status().is(404)).andReturn();
 
-    verify(commonsRepository, times(1)).findById(eq(2L));
+        verify(commonsRepository, times(1)).findById(eq(2L));
 
-    Map<String, Object> responseMap = responseToJson(response);
+        Map<String, Object> responseMap = responseToJson(response);
 
-    assertEquals(responseMap.get("message"), "Commons with id 2 not found");
-    assertEquals(responseMap.get("type"), "EntityNotFoundException");
-  }
+        assertEquals(responseMap.get("message"), "Commons with id 2 not found");
+        assertEquals(responseMap.get("type"), "EntityNotFoundException");
+    }
 
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void deleteCommons_test_admin_exists() throws Exception {
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void deleteCommons_test_admin_exists() throws Exception {
 
-    Commons c = Commons.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .endingDate(someOtherTime)
-        .degradationRate(50.0)
-        .showLeaderboard(false)
-        .carryingCapacity(100)
-        .build();
+        Commons c = Commons.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .endingDate(someOtherTime)
+                .degradationRate(50.0)
+                .showLeaderboard(false)
+                .carryingCapacity(100)
+                .build();
 
-    when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));
-    doNothing().when(commonsRepository).deleteById(2L);
-    doNothing().when(userCommonsRepository).deleteAllByCommonsId(2L);
+        when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));
+        doNothing().when(commonsRepository).deleteById(2L);
+        doNothing().when(userCommonsRepository).deleteAllByCommonsId(2L);
 
-    MvcResult response = mockMvc.perform(
-        delete("/api/commons?id=2")
-            .with(csrf()))
-        .andExpect(status().is(200)).andReturn();
+        MvcResult response = mockMvc.perform(
+                delete("/api/commons?id=2")
+                        .with(csrf()))
+                .andExpect(status().is(200)).andReturn();
 
-    verify(commonsRepository, times(1)).findById(2L);
-    verify(commonsRepository, times(1)).deleteById(2L);
-    verify(userCommonsRepository, times(1)).deleteAllByCommonsId(2L);
+        verify(commonsRepository, times(1)).findById(2L);
+        verify(commonsRepository, times(1)).deleteById(2L);
+        verify(userCommonsRepository, times(1)).deleteAllByCommonsId(2L);
 
-    String responseString = response.getResponse().getContentAsString();
+        String responseString = response.getResponse().getContentAsString();
 
-    String expectedString = "{\"message\":\"commons with id 2 deleted\"}";
+        String expectedString = "{\"message\":\"commons with id 2 deleted\"}";
 
-    assertEquals(expectedString, responseString);
-  }
+        assertEquals(expectedString, responseString);
+    }
 
   @WithMockUser(roles = { "ADMIN" })
   @Test
@@ -664,118 +708,117 @@ public class CommonsControllerTests extends ControllerTestCase {
       assertEquals(expectedJson, jsonResponse);
   }
 
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void deleteUserFromCommonsTest() throws Exception {
-    UserCommons uc = UserCommons.builder()
-        .id(16L)
-        .userId(1L)
-        .commonsId(2L)
-        .totalWealth(0)
-        .numOfCows(1)
-        .build();
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void deleteUserFromCommonsTest() throws Exception {
+        UserCommons uc = UserCommons.builder()
+                .id(16L)
+                .userId(1L)
+                .commonsId(2L)
+                .totalWealth(0)
+                .numOfCows(1)
+                .build();
 
-    String requestBody = mapper.writeValueAsString(uc);
+        String requestBody = mapper.writeValueAsString(uc);
 
-    when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.of(uc));
+        when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.of(uc));
 
-    MvcResult response = mockMvc
-        .perform(delete("/api/commons/2/users/1").with(csrf()).contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8").content(requestBody))
-        .andExpect(status().is(204)).andReturn();
+        MvcResult response = mockMvc
+                .perform(delete("/api/commons/2/users/1").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8").content(requestBody))
+                .andExpect(status().is(204)).andReturn();
 
-    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(2L, 1L);
-    verify(userCommonsRepository, times(1)).deleteById(16L);
+        verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(2L, 1L);
+        verify(userCommonsRepository, times(1)).deleteById(16L);
 
-    String responseString = response.getResponse().getContentAsString();
+        String responseString = response.getResponse().getContentAsString();
 
-    assertEquals(responseString, "");
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void deleteUserFromCommonsTest_nonexistent_userCommons() throws Exception {
-    UserCommons uc = UserCommons.builder()
-        .id(16L)
-        .userId(1L)
-        .commonsId(2L)
-        .totalWealth(0)
-        .numOfCows(1)
-        .build();
-
-    String requestBody = mapper.writeValueAsString(uc);
-
-    when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.empty());
-
-    try {
-      mockMvc
-          .perform(delete("/api/commons/2/users/1").with(csrf()).contentType(MediaType.APPLICATION_JSON)
-              .characterEncoding("utf-8").content(requestBody))
-          .andExpect(status().is(204)).andReturn();
-
-      // The way this works is very interesting. The error message is sent as the
-      // value of a nested exception.
-    } catch (Exception e) {
-      assertEquals(e.toString(),
-          "org.springframework.web.util.NestedServletException: Request processing failed; nested exception is java.lang.Exception: UserCommons with commonsId=2 and userId=1 not found.");
+        assertEquals(responseString, "");
     }
-  }
 
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void getCommonsPlusTest() throws Exception {
-    List<Commons> expectedCommons = new ArrayList<Commons>();
-    Commons Commons1 = Commons.builder().name("TestCommons1").id(1L).build();
-    Commons Commons2 = Commons.builder().name("TestCommons2").id(2L).build();
-    Commons Commons3 = Commons.builder().name("TestCommons3").id(3L).build();
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void deleteUserFromCommonsTest_nonexistent_userCommons() throws Exception {
+        UserCommons uc = UserCommons.builder()
+                .id(16L)
+                .userId(1L)
+                .commonsId(2L)
+                .totalWealth(0)
+                .numOfCows(1)
+                .build();
 
-    expectedCommons.add(Commons1);
-    expectedCommons.add(Commons2);
-    expectedCommons.add(Commons3);
+        String requestBody = mapper.writeValueAsString(uc);
 
-    List<CommonsPlus> expectedCommonsPlusList = new ArrayList<CommonsPlus>();
-    CommonsPlus commonsPlus1 = CommonsPlus.builder()
-        .commons(Commons1)
-        .totalCows(50)
-        .totalUsers(20)
-        .build();
+        when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.empty());
 
-    CommonsPlus commonsPlus2 = CommonsPlus.builder()
-        .commons(Commons2)
-        .totalCows(0)
-        .totalUsers(0)
-        .build();
+        try {
+            mockMvc
+                    .perform(delete("/api/commons/2/users/1").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+                            .characterEncoding("utf-8").content(requestBody))
+                    .andExpect(status().is(204)).andReturn();
 
+            // The way this works is very interesting. The error message is sent as the
+            // value of a nested exception.
+        } catch (Exception e) {
+            assertEquals(e.toString(),
+                    "org.springframework.web.util.NestedServletException: Request processing failed; nested exception is java.lang.Exception: UserCommons with commonsId=2 and userId=1 not found.");
+        }
+    }
 
-    CommonsPlus commonsPlus3 = CommonsPlus.builder()
-        .commons(Commons3)
-        .totalCows(60)
-        .totalUsers(30)
-        .build();
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void getCommonsPlusTest() throws Exception {
+        List<Commons> expectedCommons = new ArrayList<Commons>();
+        Commons Commons1 = Commons.builder().name("TestCommons1").id(1L).build();
+        Commons Commons2 = Commons.builder().name("TestCommons2").id(2L).build();
+        Commons Commons3 = Commons.builder().name("TestCommons3").id(3L).build();
 
-    expectedCommonsPlusList.add(commonsPlus1);
-    expectedCommonsPlusList.add(commonsPlus2);
-    expectedCommonsPlusList.add(commonsPlus3);
+        expectedCommons.add(Commons1);
+        expectedCommons.add(Commons2);
+        expectedCommons.add(Commons3);
 
-    when(commonsRepository.findAll()).thenReturn(expectedCommons);
-    when(commonsRepository.getNumCows(eq(1L))).thenReturn(Optional.of(50));
-    when(commonsRepository.getNumUsers(eq(1L))).thenReturn(Optional.of(20));
-    when(commonsRepository.getNumCows(eq(2L))).thenReturn(Optional.empty());
-    when(commonsRepository.getNumUsers(eq(2L))).thenReturn(Optional.empty());
-    when(commonsRepository.getNumCows(eq(3L))).thenReturn(Optional.of(60));
-    when(commonsRepository.getNumUsers(eq(3L))).thenReturn(Optional.of(30));
+        List<CommonsPlus> expectedCommonsPlusList = new ArrayList<CommonsPlus>();
+        CommonsPlus commonsPlus1 = CommonsPlus.builder()
+                .commons(Commons1)
+                .totalCows(50)
+                .totalUsers(20)
+                .build();
 
-    MvcResult response = mockMvc.perform(get("/api/commons/allplus").contentType("application/json"))
-        .andExpect(status().isOk()).andReturn();
+        CommonsPlus commonsPlus2 = CommonsPlus.builder()
+                .commons(Commons2)
+                .totalCows(0)
+                .totalUsers(0)
+                .build();
 
-    verify(commonsRepository, times(1)).findAll();
+        CommonsPlus commonsPlus3 = CommonsPlus.builder()
+                .commons(Commons3)
+                .totalCows(60)
+                .totalUsers(30)
+                .build();
 
-    String responseString = response.getResponse().getContentAsString();
-    List<CommonsPlus> actualCommonsPlus = objectMapper.readValue(responseString,
-        new TypeReference<List<CommonsPlus>>() {
-        });
+        expectedCommonsPlusList.add(commonsPlus1);
+        expectedCommonsPlusList.add(commonsPlus2);
+        expectedCommonsPlusList.add(commonsPlus3);
 
-    assertEquals(expectedCommonsPlusList, actualCommonsPlus);
-  
+        when(commonsRepository.findAll()).thenReturn(expectedCommons);
+        when(commonsRepository.getNumCows(eq(1L))).thenReturn(Optional.of(50));
+        when(commonsRepository.getNumUsers(eq(1L))).thenReturn(Optional.of(20));
+        when(commonsRepository.getNumCows(eq(2L))).thenReturn(Optional.empty());
+        when(commonsRepository.getNumUsers(eq(2L))).thenReturn(Optional.empty());
+        when(commonsRepository.getNumCows(eq(3L))).thenReturn(Optional.of(60));
+        when(commonsRepository.getNumUsers(eq(3L))).thenReturn(Optional.of(30));
+
+        MvcResult response = mockMvc.perform(get("/api/commons/allplus").contentType("application/json"))
+                .andExpect(status().isOk()).andReturn();
+
+        verify(commonsRepository, times(1)).findAll();
+
+        String responseString = response.getResponse().getContentAsString();
+        List<CommonsPlus> actualCommonsPlus = objectMapper.readValue(responseString,
+                new TypeReference<List<CommonsPlus>>() {
+                });
+
+        assertEquals(expectedCommonsPlusList, actualCommonsPlus);
+
     }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -374,17 +374,6 @@ public class CommonsControllerTests extends ControllerTestCase {
         .carryingCapacity(-100)
         .build();
 
-    Commons commons = Commons.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(8.49)
-        .showLeaderboard(false)
-        .carryingCapacity(100)
-        .build();
-
     String requestBody = objectMapper.writeValueAsString(parameters);
 
     MvcResult response = mockMvc
@@ -414,17 +403,6 @@ public class CommonsControllerTests extends ControllerTestCase {
         .startingBalance(1020.10)
         .startingDate(someTime)
         .degradationRate(-20)
-        .showLeaderboard(false)
-        .carryingCapacity(100)
-        .build();
-
-    Commons commons = Commons.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(8.49)
         .showLeaderboard(false)
         .carryingCapacity(100)
         .build();


### PR DESCRIPTION
In this PR I added carrying capacity to the frontend create (AdminCreateCommonsPage) and edit form (when an admin clicks on the edit button).

Storybook link:
https://ucsb-cs156-f22.github.io/f22-7pm-happycows-docs-qa/storybook-qa/Ian-UpdateAdminCreate-EditPage

Updated form screenshot:
<img width="555" alt="image" src="https://user-images.githubusercontent.com/76976018/204692928-123d5563-ab14-4dc0-94bf-31b83e597537.png">

closes #61 