### PR TITLE
pc/ry/ag - add userCommons plus endpoint to make username available on leaderboard

### DIFF
--- a/frontend/src/fixtures/leaderboardFixtures.js
+++ b/frontend/src/fixtures/leaderboardFixtures.js
@@ -2,159 +2,218 @@ const leaderboardFixtures = {
     oneUserCommonsLB: 
     [
         {
-            "id":1,
-            "userId": 1,
-            "commonsId": 1,
-            "totalWealth" : 1000,
-            "numOfCows": 5
+            "userCommons": {
+                "id":1,
+                "userId": 1,
+                "commonsId": 1,
+                "totalWealth" : 1000,
+                "numOfCows": 5
+            },
+            "username": "gg"
         }
     ],
     threeUserCommonsLB:
     [
         {
-            "id":1,
-            "userId": 1,
-            "commonsId": 1,
-            "totalWealth" : 1000,
-            "numOfCows": 8
+            "userCommons":{
+                "id":1,
+                "userId": 1,
+                "commonsId": 1,
+                "totalWealth" : 1000,
+                "numOfCows": 8
+            },
+            "username": "one"
         },
         {
-            "id":2,
-            "userId": 2,
-            "commonsId": 1,
-            "totalWealth" : 1000,
-            "numOfCows": 5
+            "userCommons": {
+                "id":2,
+                "userId": 2,
+                "commonsId": 1,
+                "totalWealth" : 1000,
+                "numOfCows": 5
+            },
+            "username": "two"
         },
         {
-            "id":3,
-            "userId": 3,
-            "commonsId": 1,
-            "totalWealth" : 100000,
-            "numOfCows": 1000
+            "userCommons": {
+                "id":3,
+                "userId": 3,
+                "commonsId": 1,
+                "totalWealth" : 100000,
+                "numOfCows": 1000
+            },
+            "username": "three"
         }
     ],
     fiveUserCommonsLB: 
     [
         {
-            "id":1,
-            "userId": 1,
-            "commonsId": 1,
-            "totalWealth" : 1000,
-            "cowHealth": 93.0,
-            "numOfCows": 8
+            "userCommons": {
+                "id":1,
+                "userId": 1,
+                "commonsId": 1,
+                "totalWealth" : 1000,
+                "cowHealth": 93.0,
+                "numOfCows": 8
+            },
+            "username": "one"
         },
         {
-            "id":2,
-            "userId": 2,
-            "commonsId": 1,
-            "totalWealth" : 1000,
-            "cowHealth": 98.0,
-            "numOfCows": 5
+            "userCommons": {
+                "id":2,
+                "userId": 2,
+                "commonsId": 1,
+                "totalWealth" : 1000,
+                "cowHealth": 98.0,
+                "numOfCows": 5
+            },
+            "username": "two"
         },
         {
-            "id":3,
-            "userId": 3,
-            "commonsId": 1,
-            "totalWealth" : 100000,
-            "cowHealth": 2.0,
-            "numOfCows": 1000
+            "userCommons": {
+                "id":3,
+                "userId": 3,
+                "commonsId": 1,
+                "totalWealth" : 100000,
+                "cowHealth": 2.0,
+                "numOfCows": 1000
+            },
+            "username": "three"
         },
         {
-            "id":4,
-            "userId": 4,
-            "commonsId": 1,
-            "totalWealth" : 50,
-            "cowHealth": 84.0,
-            "numOfCows": 100
+            "userCommons": {
+                "id":4,
+                "userId": 4,
+                "commonsId": 1,
+                "totalWealth" : 50,
+                "cowHealth": 84.0,
+                "numOfCows": 100
+            },
+            "username": "four"
         },
         {
-            "id":5,
-            "userId": 5,
-            "commonsId": 1,
-            "totalWealth" : 800,
-            "numOfCows": 60
+            "userCommons": {
+                "id":5,
+                "userId": 5,
+                "commonsId": 1,
+                "totalWealth" : 800,
+                "cowHealth": 84.0,
+                "numOfCows": 60
+            },
+            "username": "five"
         }
     ],
     tenUserCommonsLB: 
     [
         {
-            "id":1,
-            "userId": 1,
-            "commonsId": 1,
-            "totalWealth" : 1000,
-            "cowHealth": 93.0,
-            "numOfCows": 8
+            "userCommons": {
+                "id":1,
+                "userId": 1,
+                "commonsId": 1,
+                "totalWealth" : 1000,
+                "cowHealth": 93.0,
+                "numOfCows": 8
+            },
+            "username": "one"
         },
         {
-            "id":2,
-            "userId": 2,
-            "commonsId": 1,
-            "totalWealth" : 1000,
-            "cowHealth": 98.0,
-            "numOfCows": 5
+            "userCommons": {
+                "id":2,
+                "userId": 2,
+                "commonsId": 1,
+                "totalWealth" : 1000,
+                "cowHealth": 98.0,
+                "numOfCows": 5
+            },
+            "username": "two"
         },
         {
-            "id":3,
-            "userId": 3,
-            "commonsId": 1,
-            "totalWealth" : 100000,
-            "cowHealth": 2.0,
-            "numOfCows": 1000
+            "userCommons": {
+                "id":3,
+                "userId": 3,
+                "commonsId": 1,
+                "totalWealth" : 100000,
+                "cowHealth": 2.0,
+                "numOfCows": 1000
+            },
+            "username": "three"
         },
         {
-            "id":4,
-            "userId": 4,
-            "commonsId": 1,
-            "totalWealth" : 50,
-            "cowHealth": 84.0,
-            "numOfCows": 100
+            "userCommons": {
+                "id":4,
+                "userId": 4,
+                "commonsId": 1,
+                "totalWealth" : 50,
+                "cowHealth": 84.0,
+                "numOfCows": 100
+            },
+            "username": "four"
         },
         {
-            "id":5,
-            "userId": 5,
-            "commonsId": 1,
-            "totalWealth" : 800,
-            "cowHealth": 72.0,
-            "numOfCows": 60
+            "userCommons": {
+                "id":5,
+                "userId": 5,
+                "commonsId": 1,
+                "totalWealth" : 800,
+                "cowHealth": 84.0,
+                "numOfCows": 60
+            },
+            "username": "five"
         },
         {
-            "id":6,
-            "userId": 6,
-            "commonsId": 1,
-            "totalWealth" : 1000,
-            "cowHealth": 93.0,
-            "numOfCows": 8
+            "userCommons": {
+                "id":6,
+                "userId": 6,
+                "commonsId": 1,
+                "totalWealth" : 321,
+                "cowHealth": 33.0,
+                "numOfCows": 7
+            },
+            "username": "gg1"
         },
         {
-            "id":7,
-            "userId": 7,
-            "commonsId": 1,
-            "totalWealth" : 1000,
-            "cowHealth": 98.0,
-            "numOfCows": 5
+            "userCommons": {
+                "id":7,
+                "userId": 7,
+                "commonsId": 1,
+                "totalWealth" : 1000,
+                "cowHealth": 98.0,
+                "numOfCows": 4
+            },
+            "username": "gg2"
         },
         {
-            "id":8,
-            "userId": 8,
-            "commonsId":  1,
-            "totalWealth" : 100000,
-            "cowHealth": 2.0,
-            "numOfCows": 1000
+            "userCommons": {
+                "id":8,
+                "userId": 8,
+                "commonsId": 1,
+                "totalWealth" : 372891,
+                "cowHealth": 2.2,
+                "numOfCows": 321
+            },
+            "username": "gg3"
         },
         {
-            "id":9,
-            "userId": 9,
-            "commonsId":  1,
-            "totalWealth" : 50,
-            "cowHealth": 84.0,
-            "numOfCows": 100
+            "userCommons": {
+                "id":9,
+                "userId": 9,
+                "commonsId": 1,
+                "totalWealth" : 31321,
+                "cowHealth": 43.0,
+                "numOfCows": 28
+            },
+            "username": "gg4"
         },
         {
-            "id":10,
-            "userId": 10,
-            "commonsId": 1,
-            "totalWealth" : 800,
-            "numOfCows": 60
+            "userCommons": {
+                "id":10,
+                "userId": 10,
+                "commonsId": 1,
+                "totalWealth" : 423,
+                "cowHealth": 32.0,
+                "numOfCows": 60
+            },
+            "username": "gg5"
         }
     ]
 }

--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -7,15 +7,19 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
     const columns = [
         {
             Header: 'User Id',
-            accessor: 'userId', 
+            accessor: 'userCommons.userId', 
+        },
+        {
+            Header: 'Username',
+            accessor: 'username',
         },
         {
             Header: 'Total Wealth',
-            accessor: 'totalWealth',
+            accessor: 'userCommons.totalWealth',
         },
         {
             Header: 'Cows Owned',
-            accessor: 'numOfCows', 
+            accessor: 'userCommons.numOfCows', 
         },
     ];
 
@@ -26,7 +30,7 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
     const columnsIfAdmin = [
         {
             Header: '(Admin) userCommons Id',
-            accessor: 'id'
+            accessor: 'userCommons.id'
         },
         ...columns
 

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -17,12 +17,12 @@ export default function LeaderboardPage() {
   const { data: currentUser } = useCurrentUser();
 
   // Stryker disable all 
-  const { data: userCommons, error: _error, status: _status } =
+  const { data: userCommonsPlus, error: _error, status: _status } =
     useBackend(
-      [`/api/usercommons/commons/all?commonsId=${commonsId}`],
+      [`/api/usercommons/commons/all/plus?commonsId=${commonsId}`],
       {
         method: "GET",
-        url: "/api/usercommons/commons/all",
+        url: "/api/usercommons/commons/all/plus",
         params: {
           commonsId: commonsId
         }
@@ -54,7 +54,7 @@ export default function LeaderboardPage() {
                 <h1>Leaderboard</h1>
                 {
                   showLeaderboard?
-                  (<LeaderboardTable leaderboardUsers={userCommons} currentUser={currentUser} />) :
+                  (<LeaderboardTable leaderboardUsers={userCommonsPlus} currentUser={currentUser} />) :
                   (<p>You're not authorized to see the leaderboard.</p>)
                 }
             </div>

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -65,8 +65,8 @@ describe("LeaderboardTable tests", () => {
 
     );
 
-    const expectedHeaders = ['(Admin) userCommons Id', 'User Id', 'Total Wealth', 'Cows Owned'];
-    const expectedFields = ['id', 'userId', 'totalWealth','numOfCows'];
+    const expectedHeaders = ['(Admin) userCommons Id', 'Username', 'User Id', 'Total Wealth', 'Cows Owned'];
+    const expectedFields = ['id', 'userId', 'username', 'totalWealth','numOfCows'];
     const testId = "LeaderboardTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -81,9 +81,11 @@ describe("LeaderboardTable tests", () => {
 
     expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-userId`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-username`)).toHaveTextContent("one");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-totalWealth`)).toHaveTextContent("1000");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-userId`)).toHaveTextContent("2");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-username`)).toHaveTextContent("two");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-totalWealth`)).toHaveTextContent("1000");
 
   });

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -65,8 +65,8 @@ describe("LeaderboardTable tests", () => {
 
     );
 
-    const expectedHeaders = ['(Admin) userCommons Id', 'Username', 'User Id', 'Total Wealth', 'Cows Owned'];
-    const expectedFields = ['id', 'userId', 'username', 'totalWealth','numOfCows'];
+    const expectedHeaders = ['(Admin) userCommons Id', 'User Id', 'Username', 'Total Wealth', 'Cows Owned'];
+    const expectedFields = ['userCommons.id', 'userCommons.userId', 'username', 'userCommons.totalWealth','userCommons.numOfCows'];
     const testId = "LeaderboardTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -79,14 +79,14 @@ describe("LeaderboardTable tests", () => {
       expect(header).toBeInTheDocument();
     });
 
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-userId`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-userCommons.id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-userCommons.userId`)).toHaveTextContent("1");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-username`)).toHaveTextContent("one");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-totalWealth`)).toHaveTextContent("1000");
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-userId`)).toHaveTextContent("2");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-userCommons.totalWealth`)).toHaveTextContent("1000");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-userCommons.id`)).toHaveTextContent("2");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-userCommons.userId`)).toHaveTextContent("2");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-username`)).toHaveTextContent("two");
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-totalWealth`)).toHaveTextContent("1000");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-userCommons.totalWealth`)).toHaveTextContent("1000");
 
   });
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -22,6 +22,7 @@ import edu.ucsb.cs156.happiercows.models.UserCommonsPlus;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import lombok.Generated;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.http.ResponseEntity;
@@ -170,13 +171,10 @@ public class UserCommonsController extends ApiController {
 
   public UserCommonsPlus toUserCommonsPlus(UserCommons uc) {
 
-    Optional<User> optionalUser = userRepository.findById(uc.getUserId());
+    User user = userRepository.findById(uc.getUserId()).orElseThrow(
+      () -> new EntityNotFoundException(User.class, uc.getUserId()));
 
-    if (!optionalUser.isPresent()) {
-      throw new RuntimeException(String.format("User with id %d not found",uc.getUserId()));
-    }
-
-    String username = optionalUser.get().getFullName(); // WRITE CODE TO GET USERNAME
+    String username = user.getFullName(); // WRITE CODE TO GET USERNAME
 
     return UserCommonsPlus.builder()
         .userCommons(uc)

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -12,16 +12,25 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
 import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
+import edu.ucsb.cs156.happiercows.models.UserCommonsPlus;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.http.ResponseEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 import javax.validation.Valid;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -31,6 +40,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Api(description = "User Commons")
 @RequestMapping("/api/usercommons")
 @RestController
+@Slf4j
 public class UserCommonsController extends ApiController {
 
   @Autowired
@@ -38,6 +48,9 @@ public class UserCommonsController extends ApiController {
 
   @Autowired
   private CommonsRepository commonsRepository;
+
+  @Autowired
+  private UserRepository userRepository;
 
   @Autowired
   ObjectMapper mapper;
@@ -73,61 +86,102 @@ public class UserCommonsController extends ApiController {
   @PreAuthorize("hasRole('ROLE_USER')")
   @PutMapping("/buy")
   public ResponseEntity<String> putUserCommonsByIdBuy(
-          @ApiParam("commonsId") @RequestParam Long commonsId) throws JsonProcessingException {
+      @ApiParam("commonsId") @RequestParam Long commonsId) throws JsonProcessingException {
 
-        User u = getCurrentUser().getUser();
-        Long userId = u.getId();
+    User u = getCurrentUser().getUser();
+    Long userId = u.getId();
 
-        Commons commons = commonsRepository.findById(commonsId).orElseThrow( 
-          ()->new EntityNotFoundException(Commons.class, commonsId));
-        UserCommons userCommons = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)
+    Commons commons = commonsRepository.findById(commonsId).orElseThrow(
+        () -> new EntityNotFoundException(Commons.class, commonsId));
+    UserCommons userCommons = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)
         .orElseThrow(
             () -> new EntityNotFoundException(UserCommons.class, "commonsId", commonsId, "userId", userId));
 
-        if(userCommons.getTotalWealth() >= commons.getCowPrice() ){
-          userCommons.setTotalWealth(userCommons.getTotalWealth() - commons.getCowPrice());
-          userCommons.setNumOfCows(userCommons.getNumOfCows() + 1);
-        }
-        userCommonsRepository.save(userCommons);
-
-        String body = mapper.writeValueAsString(userCommons);
-        return ResponseEntity.ok().body(body);
+    if (userCommons.getTotalWealth() >= commons.getCowPrice()) {
+      userCommons.setTotalWealth(userCommons.getTotalWealth() - commons.getCowPrice());
+      userCommons.setNumOfCows(userCommons.getNumOfCows() + 1);
     }
+    userCommonsRepository.save(userCommons);
+
+    String body = mapper.writeValueAsString(userCommons);
+    return ResponseEntity.ok().body(body);
+  }
 
   @ApiOperation(value = "Sell a cow, totalWealth updated")
   @PreAuthorize("hasRole('ROLE_USER')")
   @PutMapping("/sell")
   public ResponseEntity<String> putUserCommonsByIdSell(
-          @ApiParam("commonsId") @RequestParam Long commonsId) throws JsonProcessingException {
-        User u = getCurrentUser().getUser();
-        Long userId = u.getId();
+      @ApiParam("commonsId") @RequestParam Long commonsId) throws JsonProcessingException {
+    User u = getCurrentUser().getUser();
+    Long userId = u.getId();
 
-        Commons commons = commonsRepository.findById(commonsId).orElseThrow( 
-          ()->new EntityNotFoundException(Commons.class, commonsId));
-        UserCommons userCommons = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)
+    Commons commons = commonsRepository.findById(commonsId).orElseThrow(
+        () -> new EntityNotFoundException(Commons.class, commonsId));
+    UserCommons userCommons = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)
         .orElseThrow(
             () -> new EntityNotFoundException(UserCommons.class, "commonsId", commonsId, "userId", userId));
 
-
-        if(userCommons.getNumOfCows() >= 1 ){
-          userCommons.setTotalWealth(userCommons.getTotalWealth() + commons.getCowPrice());
-          userCommons.setNumOfCows(userCommons.getNumOfCows() - 1);
-        }
-        userCommonsRepository.save(userCommons);
-
-        String body = mapper.writeValueAsString(userCommons);
-        return ResponseEntity.ok().body(body);
+    if (userCommons.getNumOfCows() >= 1) {
+      userCommons.setTotalWealth(userCommons.getTotalWealth() + commons.getCowPrice());
+      userCommons.setNumOfCows(userCommons.getNumOfCows() - 1);
     }
+    userCommonsRepository.save(userCommons);
 
-    @ApiOperation(value = "Get all user commons for a specific commons")
-    @GetMapping("/commons/all")
-    public  ResponseEntity<String> getUsersCommonsByCommonsId(
-        @ApiParam("commonsId") @RequestParam Long commonsId) throws JsonProcessingException {
-      Iterable<UserCommons> uc = userCommonsRepository.findByCommonsId(commonsId);
-      
-   
+    String body = mapper.writeValueAsString(userCommons);
+    return ResponseEntity.ok().body(body);
+  }
+
+  @ApiOperation(value = "Get all user commons for a specific commons")
+  @GetMapping("/commons/all")
+  public ResponseEntity<String> getUsersCommonsByCommonsId(
+      @ApiParam("commonsId") @RequestParam Long commonsId) throws JsonProcessingException {
+    Iterable<UserCommons> uc = userCommonsRepository.findByCommonsId(commonsId);
+
     String body = mapper.writeValueAsString(uc);
     return ResponseEntity.ok().body(body);
+  }
+
+  @ApiOperation(value = "Get all user commons for a specific commons plus additional fields")
+  @GetMapping("/commons/all/plus")
+  public ResponseEntity<String> getUsersCommonsPlusByCommonsId(
+      @ApiParam("commonsId") @RequestParam Long commonsId) throws JsonProcessingException {
+    Iterable<UserCommons> ucIterable = userCommonsRepository.findByCommonsId(commonsId);
+
+    // convert Iterable to List for the purposes of using a Java Stream & lambda
+    // below
+    List<UserCommons> userCommonsList = new ArrayList<UserCommons>();
+    ucIterable.forEach(userCommonsList::add);
+
+    List<UserCommonsPlus> userCommonsPlusList1 = userCommonsList.stream()
+        .map(uc -> toUserCommonsPlus(uc))
+        .collect(Collectors.toList());
+
+    log.info("userCommonsPlusList1=" + userCommonsPlusList1);
+
+    ArrayList<UserCommonsPlus> userCommonsPlusList = new ArrayList<>(userCommonsPlusList1);
+
+    log.info("userCommonsPlusList=" + userCommonsPlusList);
+
+    String body = mapper.writeValueAsString(userCommonsPlusList);
+
+    log.info("body=" + body);
+    return ResponseEntity.ok().body(body);
+  }
+
+  public UserCommonsPlus toUserCommonsPlus(UserCommons uc) {
+
+    Optional<User> optionalUser = userRepository.findById(uc.getUserId());
+
+    if (!optionalUser.isPresent()) {
+      throw new RuntimeException(String.format("User with id %d not found",uc.getUserId()));
+    }
+
+    String username = optionalUser.get().getFullName(); // WRITE CODE TO GET USERNAME
+
+    return UserCommonsPlus.builder()
+        .userCommons(uc)
+        .username(username)
+        .build();
   }
 
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/UserCommonsPlus.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/UserCommonsPlus.java
@@ -1,0 +1,16 @@
+package edu.ucsb.cs156.happiercows.models;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+
+import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserCommonsPlus {
+    private UserCommons userCommons;
+    private String username;
+}


### PR DESCRIPTION


We add a column to show all the usernames on leaderboard. Close https://github.com/ucsb-cs156-f22/f22-7pm-happycows/issues/22, fix https://github.com/ucsb-cs156-f22/f22-7pm-happycows/pull/37 merge issue, rewrite the code on a fresh copy of main, fix the duplicate data storing issue in https://github.com/ucsb-cs156-f22/f22-7pm-happycows/pull/37#discussion_r1034173414

<img width="1440" alt="截屏2022-11-30 19 42 02" src="https://user-images.githubusercontent.com/93735732/204960739-3e5f09d4-296e-4e5c-bcde-039d1d15fa53.png">

