### PR TITLE
pc - add endpoint for commons plus and tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -142,6 +142,18 @@ public class CommonsController extends ApiController {
     return commons;
   }
 
+  @ApiOperation(value = "Get a specific commons, plus number of cows/users")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("plus")
+  public CommonsPlus getCommonsPlusById(
+      @ApiParam("id") @RequestParam Long id) throws JsonProcessingException {
+
+    Commons commons = commonsRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException(Commons.class, id));
+
+    return toCommonsPlus(commons);
+  }
+
   @ApiOperation(value = "Create a new commons")
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   @PostMapping(value = "/new", produces = "application/json")

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -436,6 +436,38 @@ public class CommonsControllerTests extends ControllerTestCase {
     assertEquals(expectedJson, responseString);
   }
 
+ // This common SHOULD be in the repository
+ @WithMockUser(roles = { "USER" })
+ @Test
+ public void getCommonsPlusByIdTest_valid() throws Exception {
+   Commons commons1 = Commons.builder()
+       .name("TestCommons2")
+       .id(18L)
+       .build();
+
+    CommonsPlus commonsPlus1 = CommonsPlus.builder()
+        .commons(commons1)
+        .totalCows(10)
+        .totalUsers(17)
+        .build();
+
+   when(commonsRepository.findById(eq(18L))).thenReturn(Optional.of(commons1));
+   when(commonsRepository.getNumCows(eq(18L))).thenReturn(Optional.of(10));
+   when(commonsRepository.getNumUsers(eq(18L))).thenReturn(Optional.of(17));
+
+   MvcResult response = mockMvc.perform(get("/api/commons/plus?id=18"))
+       .andExpect(status().isOk()).andReturn();
+
+   verify(commonsRepository, times(1)).findById(eq(18L));
+   verify(commonsRepository, times(1)).getNumCows(eq(18L));
+   verify(commonsRepository, times(1)).getNumUsers(eq(18L));
+
+   String expectedJson = mapper.writeValueAsString(commonsPlus1);
+   String responseString = response.getResponse().getContentAsString();
+   assertEquals(expectedJson, responseString);
+ }
+
+
   // This common SHOULD NOT be in the repository
   @WithMockUser(roles = { "USER" })
   @Test
@@ -444,6 +476,24 @@ public class CommonsControllerTests extends ControllerTestCase {
     when(commonsRepository.findById(eq(18L))).thenReturn(Optional.empty());
 
     MvcResult response = mockMvc.perform(get("/api/commons?id=18"))
+        .andExpect(status().is(404)).andReturn();
+
+    verify(commonsRepository, times(1)).findById(eq(18L));
+
+    Map<String, Object> responseMap = responseToJson(response);
+
+    assertEquals(responseMap.get("message"), "Commons with id 18 not found");
+    assertEquals(responseMap.get("type"), "EntityNotFoundException");
+  }
+
+  // This common SHOULD NOT be in the repository
+  @WithMockUser(roles = { "USER" })
+  @Test
+  public void getCommonsPlusByIdTest_invalid() throws Exception {
+
+    when(commonsRepository.findById(eq(18L))).thenReturn(Optional.empty());
+
+    MvcResult response = mockMvc.perform(get("/api/commons/plus?id=18"))
         .andExpect(status().is(404)).andReturn();
 
     verify(commonsRepository, times(1)).findById(eq(18L));


### PR DESCRIPTION
In this Staff PR, we illustrate how to implement a backend endpoint that provides the number of users and number of cows directly, so that the frontend doesn't have to count for itself, and we don't have to maintain a separate variable for each in the commons.